### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -28,7 +28,7 @@ pub trait HasPipeline: HasFramebuffer + HasProgram + HasTessellation + HasTextur
 ///
 /// `CS` and `DS` are – respectively – the *color* and *depth* `Slot` of the underlying
 /// `Framebuffer`.
-pub struct Pipeline<'a, C, L, D, CS, DS> 
+pub struct Pipeline<'a, C, L, D, CS, DS>
     where C: 'a + HasFramebuffer + HasProgram + HasTessellation + HasTexture,
           L: 'a + Layerable,
           D: 'a + Dimensionable,
@@ -84,7 +84,7 @@ pub struct ShadingCommand<'a, C, T> where C: 'a + HasProgram + HasTessellation, 
 impl<'a, C, T> ShadingCommand<'a, C, T> where C: 'a + HasProgram + HasTessellation {
   pub fn new<F: Fn(&T) + 'a>(program: &'a Program<C, T>, update: F, render_commands: Vec<RenderCommand<'a, C, T>>) -> Self {
     ShadingCommand {
-      program: &program,
+      program: program,
       update: Box::new(update),
       render_commands: render_commands
     }

--- a/src/shader/program.rs
+++ b/src/shader/program.rs
@@ -123,7 +123,7 @@ impl<'a, C> ProgramProxy<'a, C> where C: HasProgram {
     let ty = T::reify_type();
     let dim = T::dim();
 
-    let (u, w) = C::map_uniform(&self.repr, String::from(name), ty, dim);
+    let (u, w) = C::map_uniform(self.repr, String::from(name), ty, dim);
     (Uniform::new(u), w)
   }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -235,10 +235,10 @@ pub trait HasTexture {
   fn clear_part<L, D, P>(tex: &Self::ATexture, gen_mimpmaps: bool, offset: D::Offset, size: D::Size, pixel: P::Encoding)
     where L: Layerable, D: Dimensionable, D::Offset: Copy, D::Size: Copy, P: Pixel, P::Encoding: Copy;
   /// Upload texels to the texture’s memory.
-  fn upload_part<L, D, P>(tex: &Self::ATexture, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &Vec<P::Encoding>)
+  fn upload_part<L, D, P>(tex: &Self::ATexture, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &[P::Encoding])
     where L: Layerable, D::Offset: Copy, D::Size: Copy, D: Dimensionable, P: Pixel;
   /// Upload raw texels to the texture’s memory.
-  fn upload_part_raw<L, D, P>(tex: &Self::ATexture, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &Vec<P::RawEncoding>)
+  fn upload_part_raw<L, D, P>(tex: &Self::ATexture, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &[P::RawEncoding])
     where L: Layerable, D::Offset: Copy, D::Size: Copy, D: Dimensionable, P: Pixel;
   /// Retrieve the texels as a collection of P::RawEncoding.
   fn get_raw_texels<P>(tex: &Self::ATexture) -> Vec<P::RawEncoding> where P: Pixel, P::RawEncoding: Copy;
@@ -309,25 +309,25 @@ impl<C, L, D, P> Texture<C, L, D, P>
     self.clear_part(gen_mipmaps, D::zero_offset(), self.size, pixel)
   }
 
-  pub fn upload_part(&self, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &Vec<P::Encoding>) 
+  pub fn upload_part(&self, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &[P::Encoding])
       where D::Offset: Copy,
             D::Size: Copy {
     C::upload_part::<L, D, P>(&self.repr, gen_mipmaps, offset, size, texels)
   }
 
-  pub fn upload(&self, gen_mipmaps: bool, texels: &Vec<P::Encoding>)
+  pub fn upload(&self, gen_mipmaps: bool, texels: &[P::Encoding])
       where D::Offset: Copy,
             D::Size: Copy {
     self.upload_part(gen_mipmaps, D::zero_offset(), self.size, texels)
   }
 
-  pub fn upload_part_raw(&self, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &Vec<P::RawEncoding>) 
+  pub fn upload_part_raw(&self, gen_mipmaps: bool, offset: D::Offset, size: D::Size, texels: &[P::RawEncoding])
       where D::Offset: Copy,
             D::Size: Copy {
     C::upload_part_raw::<L, D, P>(&self.repr, gen_mipmaps, offset, size, texels)
   }
 
-  pub fn upload_raw(&self, gen_mipmaps: bool, texels: &Vec<P::RawEncoding>)
+  pub fn upload_raw(&self, gen_mipmaps: bool, texels: &[P::RawEncoding])
       where D::Offset: Copy,
             D::Size: Copy {
     self.upload_part_raw(gen_mipmaps, D::zero_offset(), self.size, texels)

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -45,7 +45,7 @@ use std::vec::Vec;
 pub type VertexFormat = Vec<VertexComponentFormat>;
 
 /// Retrieve the number of components in a `VertexFormat`.
-pub fn vertex_format_size(vf: &VertexFormat) -> usize {
+pub fn vertex_format_size(vf: &[VertexComponentFormat]) -> usize {
   vf.len()
 }
 


### PR DESCRIPTION
Small readability things and idiosyncracies (like using slices instead of `&Vec`s in function arguments).