### PR TITLE
All sampler uniforms to be generic over texture format

### DIFF
--- a/luminance/examples/06-texture/src/main.rs
+++ b/luminance/examples/06-texture/src/main.rs
@@ -19,7 +19,7 @@ extern crate luminance_glfw;
 use luminance::context::GraphicsContext;
 use luminance::framebuffer::Framebuffer;
 use luminance::pipeline::BoundTexture;
-use luminance::pixel::RGB32F;
+use luminance::pixel::{RGB32F, Floating};
 use luminance::render_state::RenderState;
 use luminance::shader::program::Program;
 use luminance::tess::{Mode, TessBuilder};
@@ -44,7 +44,7 @@ fn main() {
 uniform_interface! {
   struct ShaderInterface {
     // the 'static lifetime acts as “anything” here
-    tex: &'static BoundTexture<'static, Flat, Dim2, RGB32F>
+    tex: &'static BoundTexture<'static, Flat, Dim2, Floating>
   }
 }
 

--- a/luminance/examples/07-offscreen/src/main.rs
+++ b/luminance/examples/07-offscreen/src/main.rs
@@ -16,7 +16,7 @@ use crate::common::{Vertex, VertexPosition, VertexColor};
 use luminance::context::GraphicsContext;
 use luminance::framebuffer::Framebuffer;
 use luminance::pipeline::BoundTexture;
-use luminance::pixel::RGBA32F;
+use luminance::pixel::{RGBA32F, Floating};
 use luminance::render_state::RenderState;
 use luminance::shader::program::Program;
 use luminance::tess::{Mode, TessBuilder, TessSliceIndex};
@@ -45,7 +45,7 @@ uniform_interface! {
   struct ShaderInterface {
     // we only need the source texture (from the framebuffer) to fetch from
     #[unbound, as("source_texture")]
-    texture: &'static BoundTexture<'static, Flat, Dim2, RGBA32F>
+    texture: &'static BoundTexture<'static, Flat, Dim2, Floating>
   }
 }
 

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -92,6 +92,7 @@ pub fn is_depth_pixel(f: PixelFormat) -> bool {
 }
 
 /// The integral sample type
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Integral;
 
 unsafe impl SamplerType for Integral {
@@ -101,6 +102,7 @@ unsafe impl SamplerType for Integral {
 }
 
 /// The integral sample type
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Unsigned;
 
 unsafe impl SamplerType for Unsigned {
@@ -110,6 +112,7 @@ unsafe impl SamplerType for Unsigned {
 }
 
 /// The integral sample type
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Floating;
 
 unsafe impl SamplerType for Floating {


### PR DESCRIPTION
PR version of my prototype. Nothing has changed in the code. Copy/pasting my response to commit comments for visibility.

> The thing I'm not convinced is correct with this change is my removal of the `Texture` from the `BoundTexture` phantomtype. Glancing through the implementation of `BoundTexture` it doesn't look like we need the `Texture` to be there explicitly, but I'm not super clear on what invariants that `PhantomType` was trying to enforce -- my knowledge of unsafe Rust is relatively weak at this time. I suppose I should turn this into a proper PR to continue discussion.

Fixes #107