### PR TITLE
[RFC] Support different types for the index buffer.

### DIFF
--- a/luminance/src/lib.rs
+++ b/luminance/src/lib.rs
@@ -126,3 +126,4 @@ pub mod state;
 pub mod tess;
 pub mod texture;
 pub mod vertex;
+pub mod vertex_restart;

--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -465,7 +465,7 @@ pub struct TessGate {
 
 impl TessGate {
   /// Render a tessellation.
-  pub fn render<C, I: crate::tess::VertIndex>(&self, ctx: &mut C, tess: TessSlice<I>) where C: GraphicsContext {
+  pub fn render<C>(&self, ctx: &mut C, tess: TessSlice) where C: GraphicsContext {
     tess.render(ctx);
   }
 }

--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -465,7 +465,7 @@ pub struct TessGate {
 
 impl TessGate {
   /// Render a tessellation.
-  pub fn render<C>(&self, ctx: &mut C, tess: TessSlice) where C: GraphicsContext {
+  pub fn render<C, I: crate::tess::VertIndex>(&self, ctx: &mut C, tess: TessSlice<I>) where C: GraphicsContext {
     tess.render(ctx);
   }
 }

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -215,6 +215,15 @@ impl GraphicsState {
     }
   }
 
+  pub(crate) unsafe fn set_vertex_restart(&mut self, state: VertexRestart) {
+    if self.vertex_restart != state {
+      match state {
+        VertexRestart::Enabled => gl::Enable(gl::PRIMITIVE_RESTART),
+        VertexRestart::Disabled => gl::Disable(gl::PRIMITIVE_RESTART),
+      }
+    }
+  }
+
   pub(crate) unsafe fn set_texture_unit(&mut self, unit: u32) {
     if self.current_texture_unit != unit {
       gl::ActiveTexture(gl::TEXTURE0 + unit as GLenum);

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -145,7 +145,7 @@ struct VertexBuffer {
 pub struct TessBuilder<'a, C, I> {
   ctx: &'a mut C,
   vertex_buffers: Vec<VertexBuffer>,
-  index_buffer: Option<(RawBuffer, IndexType)>,
+  index_buffer: Option<(RawBuffer, TessIndexType)>,
   restart_index: Option<u32>,
   mode: Mode,
   vert_nb: usize,
@@ -173,7 +173,7 @@ impl<'a, C, I> TessBuilder<'a, C, I> {
 impl<'a, C, I> TessBuilder<'a, C, I>
 where
   C: GraphicsContext,
-  I: VertIndex,
+  I: TessIndex,
 {
   /// Add vertices to be part of the tessellation.
   ///
@@ -288,7 +288,7 @@ where
           Some(IndexedDrawState {
             restart_index: self.restart_index,
             buffer,
-            index_type
+            index_type,
           })
         }
         None => None,
@@ -418,49 +418,51 @@ pub enum TessError {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum IndexType {
-    U8, U16, U32,
+pub enum TessIndexType {
+  U8,
+  U16,
+  U32,
 }
 
-impl IndexType {
-    fn to_glenum(self) -> GLenum {
-        match self {
-            IndexType::U8 => gl::UNSIGNED_BYTE,
-            IndexType::U16 => gl::UNSIGNED_SHORT,
-            IndexType::U32 => gl::UNSIGNED_INT,
-        }
+impl TessIndexType {
+  fn to_glenum(self) -> GLenum {
+    match self {
+      TessIndexType::U8 => gl::UNSIGNED_BYTE,
+      TessIndexType::U16 => gl::UNSIGNED_SHORT,
+      TessIndexType::U32 => gl::UNSIGNED_INT,
     }
+  }
 
-    fn size(self) -> usize {
-        match self {
-            IndexType::U8 => 1,
-            IndexType::U16 => 2,
-            IndexType::U32 => 4,
-        }
+  fn size(self) -> usize {
+    match self {
+      TessIndexType::U8 => 1,
+      TessIndexType::U16 => 2,
+      TessIndexType::U32 => 4,
     }
+  }
 }
 
-pub unsafe trait VertIndex {
-    const INDEX_TYPE: IndexType;
+pub unsafe trait TessIndex {
+  const INDEX_TYPE: TessIndexType;
 }
 
-unsafe impl VertIndex for u8 {
-    const INDEX_TYPE: IndexType = IndexType::U8;
+unsafe impl TessIndex for u8 {
+  const INDEX_TYPE: TessIndexType = TessIndexType::U8;
 }
 
-unsafe impl VertIndex for u16 {
-    const INDEX_TYPE: IndexType = IndexType::U16;
+unsafe impl TessIndex for u16 {
+  const INDEX_TYPE: TessIndexType = TessIndexType::U16;
 }
 
-unsafe impl VertIndex for u32 {
-    const INDEX_TYPE: IndexType = IndexType::U32;
+unsafe impl TessIndex for u32 {
+  const INDEX_TYPE: TessIndexType = TessIndexType::U32;
 }
 
 /// All the data extra data required when doing indexed drawing
 struct IndexedDrawState {
   buffer: RawBuffer,
   restart_index: Option<u32>,
-  index_type: IndexType,
+  index_type: TessIndexType,
 }
 
 pub struct Tess {

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -57,10 +57,6 @@
 #[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
-use std::marker::PhantomData;
-#[cfg(feature = "std")]
-use std::mem::size_of;
-#[cfg(feature = "std")]
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 #[cfg(feature = "std")]
 use std::os::raw::c_void;
@@ -71,10 +67,6 @@ use std::ptr;
 use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use core::fmt;
-#[cfg(not(feature = "std"))]
-use core::marker::PhantomData;
-#[cfg(not(feature = "std"))]
-use core::mem::size_of;
 #[cfg(not(feature = "std"))]
 use core::ops::{Range, RangeFrom, RangeFull, RangeTo};
 #[cfg(not(feature = "std"))]
@@ -142,7 +134,7 @@ struct VertexBuffer {
 }
 
 /// Build tessellations the easy way.
-pub struct TessBuilder<'a, C, I> {
+pub struct TessBuilder<'a, C> {
   ctx: &'a mut C,
   vertex_buffers: Vec<VertexBuffer>,
   index_buffer: Option<(RawBuffer, TessIndexType)>,
@@ -151,10 +143,9 @@ pub struct TessBuilder<'a, C, I> {
   vert_nb: usize,
   instance_buffers: Vec<VertexBuffer>,
   inst_nb: usize,
-  _phantom: PhantomData<I>,
 }
 
-impl<'a, C, I> TessBuilder<'a, C, I> {
+impl<'a, C> TessBuilder<'a, C> {
   pub fn new(ctx: &'a mut C) -> Self {
     TessBuilder {
       ctx,
@@ -165,15 +156,13 @@ impl<'a, C, I> TessBuilder<'a, C, I> {
       vert_nb: 0,
       instance_buffers: Vec::new(),
       inst_nb: 0,
-      _phantom: PhantomData,
     }
   }
 }
 
-impl<'a, C, I> TessBuilder<'a, C, I>
+impl<'a, C> TessBuilder<'a, C>
 where
   C: GraphicsContext,
-  I: TessIndex,
 {
   /// Add vertices to be part of the tessellation.
   ///
@@ -215,8 +204,10 @@ where
   }
 
   /// Set vertex indices in order to specify how vertices should be picked by the GPU pipeline.
-  pub fn set_indices<T>(mut self, indices: T) -> Self
-  where T: AsRef<[I]> {
+  pub fn set_indices<T, I>(mut self, indices: T) -> Self
+  where
+    T: AsRef<[I]>,
+    I: TessIndex  {
     let indices = indices.as_ref();
 
     // create a new raw buffer containing the indices and turn it into a vertex buffer

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -278,7 +278,7 @@ where
         Some((buffer, index_type)) => {
           Some(IndexedDrawState {
             restart_index: self.restart_index,
-            buffer,
+            _buffer: buffer,
             index_type,
           })
         }
@@ -451,7 +451,7 @@ unsafe impl TessIndex for u32 {
 
 /// All the data extra data required when doing indexed drawing
 struct IndexedDrawState {
-  buffer: RawBuffer,
+  _buffer: RawBuffer,
   restart_index: Option<u32>,
   index_type: TessIndexType,
 }

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -79,6 +79,7 @@ use vertex::{
   IndexedVertexAttribFmt, Vertex, VertexAttribDim, VertexAttribFmt, VertexAttribType, VertexFmt,
   VertexInstancing
 };
+use vertex_restart::VertexRestart;
 
 /// Vertices can be connected via several modes.
 #[derive(Copy, Clone, Debug)]
@@ -481,17 +482,18 @@ impl Tess {
     let inst_nb = inst_nb as GLsizei;
 
     unsafe {
-      ctx.state().borrow_mut().bind_vertex_array(self.vao);
+      let mut gfx_st = ctx.state().borrow_mut();
+      gfx_st.bind_vertex_array(self.vao);
 
       if let Some(index_state) = self.index_state.as_ref() {
         // indexed render
         let first = (index_state.index_type.bytes() * start_index) as *const c_void;
 
         if let Some(restart_index) = index_state.restart_index {
-          gl::Enable(gl::PRIMITIVE_RESTART);
+          gfx_st.set_vertex_restart(VertexRestart::Enabled);
           gl::PrimitiveRestartIndex(restart_index);
         } else {
-          gl::Disable(gl::PRIMITIVE_RESTART);
+          gfx_st.set_vertex_restart(VertexRestart::Disabled);
         }
 
         if inst_nb <= 1 {

--- a/luminance/src/vertex_restart.rs
+++ b/luminance/src/vertex_restart.rs
@@ -1,0 +1,10 @@
+//! Vertex restart related features.
+
+/// Whether or not vertex restart is enabled.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VertexRestart {
+  /// Vertex restart is enabled.
+  Enabled,
+  /// Vertex restart is disabled.
+  Disabled,
+}


### PR DESCRIPTION
Using `u32` all the time is massively wasteful for many workloads, since we rarely have meshes with more than 65535 vertexes (so we can get away with `u16`s).  GL also supports `u8` index buffers, which are handy for very small meshes, like the full-screen triangles often used for lots of post-processing effects, so we add support for those as well since it's easy enough to do. We may also want to add support for `()` as an "index buffer type" for directly rendered meshes, as right now the user needs to arbitrarily pick a type (from `u8`, `u16`, or `u32`) to fill the `Tess` type parameter