### PR TITLE
Enhance the CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
   - rustc --version
   - cargo --version
-  - cargo build --verbose
-  - cargo test --lib --verbose
+  - cargo build
+  - cargo test
   # luminance examples
   - cd luminance/examples && cargo check --verbose


### PR DESCRIPTION
We’re now testing everything (even documentation). Also, removes the
verbose output. I’ve never needed that and it should be easy to rebuild
a failed job in verbose if needed (but I really doubt we will ever).

> This is going to fail at the first time because some fix for the doc is present in another PR. I’ll rebase when it’s okay to.