### PR TITLE
Add samples to WindowOpt - #91

### DIFF
--- a/luminance-glfw/src/surface.rs
+++ b/luminance-glfw/src/surface.rs
@@ -47,6 +47,7 @@ impl Surface for GlfwSurface {
     glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
     glfw.window_hint(glfw::WindowHint::ContextVersionMajor(3));
     glfw.window_hint(glfw::WindowHint::ContextVersionMinor(3));
+    glfw.window_hint(glfw::WindowHint::Samples(win_opt.num_samples()));
 
     // open a window in windowed or fullscreen mode
     let (mut window, events_rx) = match dim {

--- a/luminance-windowing/src/lib.rs
+++ b/luminance-windowing/src/lib.rs
@@ -59,7 +59,8 @@ pub struct WindowOpt {
 impl Default for WindowOpt {
   /// Defaults:
   ///
-  /// - `hide_cursor(false)`
+  /// - `hide_cursor` set to `false`.
+  /// - `num_samples` set to `None`.
   fn default() -> Self {
     WindowOpt {
       hide_cursor: false,
@@ -78,19 +79,24 @@ impl WindowOpt {
     }
   }
 
+  /// Check whether the cursor is hidden.
   #[inline]
   pub fn is_cursor_hidden(&self) -> bool {
     self.hide_cursor
   }
 
+  /// Set the number of samples to use for multisampling.
+  ///
+  /// Pass `None` to disable multisampling.
   #[inline]
-  pub fn set_num_samples(self, samples: Option<u32>) -> Self {
+  pub fn set_num_samples<S>(self, samples: S) -> Self where S: Into<Option<u32>> {
     WindowOpt {
-      num_samples: samples,
+      num_samples: samples.into(),
       ..self
     }
   }
 
+  /// Get the number of samples to use in multisampling, if any.
   #[inline]
   pub fn num_samples(&self) -> Option<u32> {
     self.num_samples

--- a/luminance-windowing/src/lib.rs
+++ b/luminance-windowing/src/lib.rs
@@ -53,6 +53,7 @@ pub enum WindowDim {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WindowOpt {
   hide_cursor: bool,
+  num_samples: Option<u32>,
 }
 
 impl Default for WindowOpt {
@@ -60,7 +61,10 @@ impl Default for WindowOpt {
   ///
   /// - `hide_cursor(false)`
   fn default() -> Self {
-    WindowOpt { hide_cursor: false }
+    WindowOpt {
+      hide_cursor: false,
+      num_samples: None,
+    }
   }
 }
 
@@ -77,6 +81,19 @@ impl WindowOpt {
   #[inline]
   pub fn is_cursor_hidden(&self) -> bool {
     self.hide_cursor
+  }
+
+  #[inline]
+  pub fn set_num_samples(self, samples: Option<u32>) -> Self {
+    WindowOpt {
+      num_samples: samples,
+      ..self
+    }
+  }
+
+  #[inline]
+  pub fn num_samples(&self) -> Option<u32> {
+    self.num_samples
   }
 }
 


### PR DESCRIPTION
Set glfw window hint Samples from WindowOpt.
By default this is None and behavior is unchanged.