### PR TITLE
Update dependencies, and fix warnings

### DIFF
--- a/luminance-glfw/Cargo.toml
+++ b/luminance-glfw/Cargo.toml
@@ -17,7 +17,12 @@ is-it-maintained-open-issues = { repository = "phaazon/luminance" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-gl = "0.10"
-glfw = "0.23"
+gl = "0.13"
+glfw = { version = "0.30", default-features = false }
 luminance = { version = "0.30", path = "../luminance" }
 luminance-windowing = { version = "0.2", path = "../luminance-windowing" }
+
+[features]
+all = ["glfw-sys"]
+glfw-sys = ["glfw/glfw-sys"]
+default = ["glfw-sys"]

--- a/luminance-glfw/src/surface.rs
+++ b/luminance-glfw/src/surface.rs
@@ -102,12 +102,12 @@ impl Surface for GlfwSurface {
     [x as u32, y as u32]
   }
 
-  fn wait_events<'a>(&'a mut self) -> Box<Iterator<Item = Self::Event> + 'a> {
+  fn wait_events<'a>(&'a mut self) -> Box<dyn Iterator<Item = Self::Event> + 'a> {
     self.window.glfw.wait_events();
     Box::new(self.events_rx.iter().map(|(_, e)| e))
   }
 
-  fn poll_events<'a>(&'a mut self) -> Box<Iterator<Item = Self::Event> + 'a> {
+  fn poll_events<'a>(&'a mut self) -> Box<dyn Iterator<Item = Self::Event> + 'a> {
     self.window.glfw.poll_events();
     Box::new(self.events_rx.try_iter().map(|(_, e)| e))
   }

--- a/luminance-windowing/src/lib.rs
+++ b/luminance-windowing/src/lib.rs
@@ -118,9 +118,9 @@ pub trait Surface: GraphicsContext + Sized {
 
   // FIXME: existential impl trait
   /// Get an iterator over events by blocking until the first event happens.
-  fn wait_events<'a>(&'a mut self) -> Box<Iterator<Item = Self::Event> + 'a>;
+  fn wait_events<'a>(&'a mut self) -> Box<dyn Iterator<Item = Self::Event> + 'a>;
 
   // FIXME: existential impl trait
   /// Get an iterator over events without blocking if no event is there.
-  fn poll_events<'a>(&'a mut self) -> Box<Iterator<Item = Self::Event> + 'a>;
+  fn poll_events<'a>(&'a mut self) -> Box<dyn Iterator<Item = Self::Event> + 'a>;
 }

--- a/luminance/Cargo.toml
+++ b/luminance/Cargo.toml
@@ -23,5 +23,5 @@ default = ["std"]
 std = ["gl"]
 
 [dependencies.gl]
-version = "0.10"
+version = "0.13"
 optional = true

--- a/luminance/examples/06-texture/Cargo.toml
+++ b/luminance/examples/06-texture/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-image = "0.19"
+image = "0.22"
 luminance = { version = "0.30", path = "../.." }
 luminance-derive = { version = "0.1", path = "../../../luminance-derive" }
 luminance-glfw = { version = "0.5", path = "../../../luminance-glfw" }


### PR DESCRIPTION
This also removes the default features on glfw, these can be enabled by a user of this library down the road if they need them.