### PR TITLE
Update glfw to 0.31

### DIFF
--- a/luminance-glfw/Cargo.toml
+++ b/luminance-glfw/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 gl = "0.13"
-glfw = { version = "0.30", default-features = false }
+glfw = { version = "0.31", default-features = false }
 luminance = { version = "0.30", path = "../luminance" }
 luminance-windowing = { version = "0.2", path = "../luminance-windowing" }
 


### PR DESCRIPTION
This gets rid of semver 0.2.3 and thus of nom 1.2.4.