### PR TITLE
Implement unsigned byte formats

### DIFF
--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -9,7 +9,7 @@ pub unsafe trait Pixel {
   /// Encoding of a single pixel. It should match the `PixelFormat` mapping.
   type Encoding;
   /// Raw encoding of a single pixel; i.e. that is, encoding of underlying values in contiguous
-  /// texture memory. It should be match the `PixelFormat` mapping.
+  /// texture memory. It should match the `PixelFormat` mapping.
   type RawEncoding;
 
   /// The type of sampler required to access this pixel format

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -12,7 +12,7 @@ pub unsafe trait Pixel {
   /// texture memory. It should match the `PixelFormat` mapping.
   type RawEncoding;
 
-  /// The type of sampler required to access this pixel format
+  /// The type of sampler required to access this pixel format.
   type SamplerType: SamplerType;
 
   /// Reify to `PixelFormat`.
@@ -91,7 +91,7 @@ pub fn is_depth_pixel(f: PixelFormat) -> bool {
   !is_color_pixel(f)
 }
 
-/// The integral sample type
+/// The integral sample type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Integral;
 
@@ -101,7 +101,7 @@ unsafe impl SamplerType for Integral {
   }
 }
 
-/// The integral sample type
+/// The unsigned integral sample type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Unsigned;
 
@@ -111,7 +111,7 @@ unsafe impl SamplerType for Unsigned {
   }
 }
 
-/// The integral sample type
+/// The floating sample type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Floating;
 
@@ -172,13 +172,13 @@ impl_Pixel!(R8UI, u8, u8, Unsigned, Format::R(Size::Eight));
 impl_ColorPixel!(R8UI);
 impl_RenderablePixel!(R8UI);
 
-/// A red 8-bit unsigned integral pixel format, accessed as floating pixel format.
+/// A red 8-bit unsigned integral pixel format, accessed as normalized floating pixels.
 #[derive(Clone, Copy, Debug)]
-pub struct R8UIF;
+pub struct NormR8UI;
 
-impl_Pixel!(R8UIF, u8, u8, Floating, Format::R(Size::Eight));
-impl_ColorPixel!(R8UIF);
-impl_RenderablePixel!(R8UIF);
+impl_Pixel!(NormR8UI, u8, u8, Floating, Format::R(Size::Eight));
+impl_ColorPixel!(NormR8UI);
+impl_RenderablePixel!(NormR8UI);
 
 // --------------------
 
@@ -248,19 +248,19 @@ impl_Pixel!(
 impl_ColorPixel!(RG8UI);
 impl_RenderablePixel!(RG8UI);
 
-/// A red and green 8-bit unsigned integral pixel format, accessed as floating pixel format.
+/// A red and green 8-bit unsigned integral pixel format, accessed as normalized floating pixels.
 #[derive(Clone, Copy, Debug)]
-pub struct RG8UIF;
+pub struct NormRG8UI;
 
 impl_Pixel!(
-  RG8UIF,
+  NormRG8UI,
   (u8, u8),
   u8,
   Floating,
   Format::RG(Size::Eight, Size::Eight)
 );
-impl_ColorPixel!(RG8UIF);
-impl_RenderablePixel!(RG8UIF);
+impl_ColorPixel!(NormRG8UI);
+impl_RenderablePixel!(NormRG8UI);
 
 // --------------------
 
@@ -366,19 +366,20 @@ impl_Pixel!(
 impl_ColorPixel!(RGB8UI);
 impl_RenderablePixel!(RGB8UI);
 
-/// A red, green and blue 8-bit unsigned integral pixel format, accessed as floating pixel format.
+/// A red, green and blue 8-bit unsigned integral pixel format, accessed as normalized floating
+/// pixels.
 #[derive(Clone, Copy, Debug)]
-pub struct RGB8UIF;
+pub struct NormRGB8UI;
 
 impl_Pixel!(
-  RGB8UIF,
+  NormRGB8UI,
   (u8, u8, u8),
   u8,
   Floating,
   Format::RGB(Size::Eight, Size::Eight, Size::Eight)
 );
-impl_ColorPixel!(RGB8UIF);
-impl_RenderablePixel!(RGB8UIF);
+impl_ColorPixel!(NormRGB8UI);
+impl_RenderablePixel!(NormRGB8UI);
 
 // --------------------
 
@@ -484,20 +485,20 @@ impl_Pixel!(
 impl_ColorPixel!(RGBA8UI);
 impl_RenderablePixel!(RGBA8UI);
 
-/// A red, green, blue and alpha 8-bit unsigned integral pixel format, accessed as floating pixel
-/// format.
+/// A red, green, blue and alpha 8-bit unsigned integral pixel format, accessed as normalized
+/// floating pixels.
 #[derive(Clone, Copy, Debug)]
-pub struct RGBA8UIF;
+pub struct NormRGBA8UI;
 
 impl_Pixel!(
-  RGBA8UIF,
+  NormRGBA8UI,
   (u8, u8, u8, u8),
   u8,
   Floating,
   Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
 );
-impl_ColorPixel!(RGBA8UIF);
-impl_RenderablePixel!(RGBA8UIF);
+impl_ColorPixel!(NormRGBA8UI);
+impl_RenderablePixel!(NormRGBA8UI);
 
 // --------------------
 

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -156,6 +156,14 @@ macro_rules! impl_RenderablePixel {
   };
 }
 
+/// A red 8-bit unsigned integral pixel format, accessed as floats.
+#[derive(Clone, Copy, Debug)]
+pub struct R;
+
+impl_Pixel!(R, u8, u8, Floating, Format::R(Size::Eight));
+impl_ColorPixel!(R);
+impl_RenderablePixel!(R);
+
 /// A red 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
 pub struct R8I;
@@ -217,6 +225,20 @@ impl_ColorPixel!(R32F);
 impl_RenderablePixel!(R32F);
 
 // --------------------
+
+/// A red and green 8-bit unsigned integral pixel format, accessed as floats.
+#[derive(Clone, Copy, Debug)]
+pub struct RG;
+
+impl_Pixel!(
+  RG,
+  (u8, u8),
+  u8,
+  Floating,
+  Format::RG(Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RG);
+impl_RenderablePixel!(RG);
 
 /// A red and green 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
@@ -315,6 +337,20 @@ impl_ColorPixel!(RG32F);
 impl_RenderablePixel!(RG32F);
 
 // --------------------
+
+/// A red, green and blue 8-bit unsigned integral pixel format, accessed as floats.
+#[derive(Clone, Copy, Debug)]
+pub struct RGB;
+
+impl_Pixel!(
+  RGB,
+  (u8, u8, u8),
+  u8,
+  Floating,
+  Format::RGB(Size::Eight, Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RGB);
+impl_RenderablePixel!(RGB);
 
 /// A red, green and blue 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
@@ -419,6 +455,20 @@ impl_ColorPixel!(RGB32F);
 impl_RenderablePixel!(RGB32F);
 
 // --------------------
+
+/// A red, green, blue and alpha 8-bit unsigned integral pixel format, accessed as floats.
+#[derive(Clone, Copy, Debug)]
+pub struct RGBA;
+
+impl_Pixel!(
+  RGBA,
+  (u8, u8, u8, u8),
+  u8,
+  Floating,
+  Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RGBA);
+impl_RenderablePixel!(RGBA);
 
 /// A red, green, blue and alpha 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -639,9 +639,10 @@ pub(crate) fn opengl_pixel_format(pf: PixelFormat) -> Option<(GLenum, GLenum, GL
 // Return the number of components.
 pub(crate) fn pixel_components(pf: PixelFormat) -> usize {
   match pf.format {
+    Format::R(_) => 1,
+    Format::RG(_, _) => 2,
     Format::RGB(_, _, _) => 3,
     Format::RGBA(_, _, _, _) => 4,
     Format::Depth(_) => 1,
-    _ => panic!("unsupported pixel format"),
   }
 }

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -156,14 +156,6 @@ macro_rules! impl_RenderablePixel {
   };
 }
 
-/// A red 8-bit unsigned integral pixel format, accessed as floats.
-#[derive(Clone, Copy, Debug)]
-pub struct R;
-
-impl_Pixel!(R, u8, u8, Floating, Format::R(Size::Eight));
-impl_ColorPixel!(R);
-impl_RenderablePixel!(R);
-
 /// A red 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
 pub struct R8I;
@@ -179,6 +171,14 @@ pub struct R8UI;
 impl_Pixel!(R8UI, u8, u8, Unsigned, Format::R(Size::Eight));
 impl_ColorPixel!(R8UI);
 impl_RenderablePixel!(R8UI);
+
+/// A red 8-bit unsigned integral pixel format, accessed as floating pixel format.
+#[derive(Clone, Copy, Debug)]
+pub struct R8UIF;
+
+impl_Pixel!(R8UIF, u8, u8, Floating, Format::R(Size::Eight));
+impl_ColorPixel!(R8UIF);
+impl_RenderablePixel!(R8UIF);
 
 // --------------------
 
@@ -226,20 +226,6 @@ impl_RenderablePixel!(R32F);
 
 // --------------------
 
-/// A red and green 8-bit unsigned integral pixel format, accessed as floats.
-#[derive(Clone, Copy, Debug)]
-pub struct RG;
-
-impl_Pixel!(
-  RG,
-  (u8, u8),
-  u8,
-  Floating,
-  Format::RG(Size::Eight, Size::Eight)
-);
-impl_ColorPixel!(RG);
-impl_RenderablePixel!(RG);
-
 /// A red and green 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
 pub struct RG8I;
@@ -261,6 +247,20 @@ impl_Pixel!(
 );
 impl_ColorPixel!(RG8UI);
 impl_RenderablePixel!(RG8UI);
+
+/// A red and green 8-bit unsigned integral pixel format, accessed as floating pixel format.
+#[derive(Clone, Copy, Debug)]
+pub struct RG8UIF;
+
+impl_Pixel!(
+  RG8UIF,
+  (u8, u8),
+  u8,
+  Floating,
+  Format::RG(Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RG8UIF);
+impl_RenderablePixel!(RG8UIF);
 
 // --------------------
 
@@ -338,20 +338,6 @@ impl_RenderablePixel!(RG32F);
 
 // --------------------
 
-/// A red, green and blue 8-bit unsigned integral pixel format, accessed as floats.
-#[derive(Clone, Copy, Debug)]
-pub struct RGB;
-
-impl_Pixel!(
-  RGB,
-  (u8, u8, u8),
-  u8,
-  Floating,
-  Format::RGB(Size::Eight, Size::Eight, Size::Eight)
-);
-impl_ColorPixel!(RGB);
-impl_RenderablePixel!(RGB);
-
 /// A red, green and blue 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
 pub struct RGB8I;
@@ -379,6 +365,20 @@ impl_Pixel!(
 );
 impl_ColorPixel!(RGB8UI);
 impl_RenderablePixel!(RGB8UI);
+
+/// A red, green and blue 8-bit unsigned integral pixel format, accessed as floating pixel format.
+#[derive(Clone, Copy, Debug)]
+pub struct RGB8UIF;
+
+impl_Pixel!(
+  RGB8UIF,
+  (u8, u8, u8),
+  u8,
+  Floating,
+  Format::RGB(Size::Eight, Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RGB8UIF);
+impl_RenderablePixel!(RGB8UIF);
 
 // --------------------
 
@@ -456,20 +456,6 @@ impl_RenderablePixel!(RGB32F);
 
 // --------------------
 
-/// A red, green, blue and alpha 8-bit unsigned integral pixel format, accessed as floats.
-#[derive(Clone, Copy, Debug)]
-pub struct RGBA;
-
-impl_Pixel!(
-  RGBA,
-  (u8, u8, u8, u8),
-  u8,
-  Floating,
-  Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
-);
-impl_ColorPixel!(RGBA);
-impl_RenderablePixel!(RGBA);
-
 /// A red, green, blue and alpha 8-bit signed integral pixel format.
 #[derive(Clone, Copy, Debug)]
 pub struct RGBA8I;
@@ -497,6 +483,21 @@ impl_Pixel!(
 );
 impl_ColorPixel!(RGBA8UI);
 impl_RenderablePixel!(RGBA8UI);
+
+/// A red, green, blue and alpha 8-bit unsigned integral pixel format, accessed as floating pixel
+/// format.
+#[derive(Clone, Copy, Debug)]
+pub struct RGBA8UIF;
+
+impl_Pixel!(
+  RGBA8UIF,
+  (u8, u8, u8, u8),
+  u8,
+  Floating,
+  Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
+);
+impl_ColorPixel!(RGBA8UIF);
+impl_RenderablePixel!(RGBA8UIF);
 
 // --------------------
 

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -597,6 +597,7 @@ impl_DepthPixel!(Depth32F);
 // OpenGL format, internal sized-format and type.
 pub(crate) fn opengl_pixel_format(pf: PixelFormat) -> Option<(GLenum, GLenum, GLenum)> {
   match (pf.format, pf.encoding) {
+    (Format::R(Size::Eight), Type::Floating) => Some((gl::RED, gl::RED, gl::UNSIGNED_BYTE)),
     (Format::R(Size::Eight), Type::Integral) => Some((gl::RED_INTEGER, gl::R8I, gl::BYTE)),
     (Format::R(Size::Eight), Type::Unsigned) => Some((gl::RED_INTEGER, gl::R8UI, gl::UNSIGNED_BYTE)),
     (Format::R(Size::Sixteen), Type::Integral) => Some((gl::RED_INTEGER, gl::R16I, gl::SHORT)),
@@ -605,6 +606,7 @@ pub(crate) fn opengl_pixel_format(pf: PixelFormat) -> Option<(GLenum, GLenum, GL
     (Format::R(Size::ThirtyTwo), Type::Unsigned) => Some((gl::RED_INTEGER, gl::R32UI, gl::UNSIGNED_INT)),
     (Format::R(Size::ThirtyTwo), Type::Floating) => Some((gl::RED, gl::R32F, gl::FLOAT)),
 
+    (Format::RG(Size::Eight, Size::Eight), Type::Floating) => Some((gl::RG, gl::RG, gl::UNSIGNED_BYTE)),
     (Format::RG(Size::Eight, Size::Eight), Type::Integral) => Some((gl::RG_INTEGER, gl::RG8I, gl::BYTE)),
     (Format::RG(Size::Eight, Size::Eight), Type::Unsigned) => Some((gl::RG_INTEGER, gl::RG8UI, gl::UNSIGNED_BYTE)),
     (Format::RG(Size::Sixteen, Size::Sixteen), Type::Integral) => Some((gl::RG_INTEGER, gl::RG16I, gl::SHORT)),
@@ -613,6 +615,7 @@ pub(crate) fn opengl_pixel_format(pf: PixelFormat) -> Option<(GLenum, GLenum, GL
     (Format::RG(Size::ThirtyTwo, Size::ThirtyTwo), Type::Unsigned) => Some((gl::RG_INTEGER, gl::RG32UI, gl::UNSIGNED_INT)),
     (Format::RG(Size::ThirtyTwo, Size::ThirtyTwo), Type::Floating) => Some((gl::RG, gl::RG32F, gl::FLOAT)),
 
+    (Format::RGB(Size::Eight, Size::Eight, Size::Eight), Type::Floating) => Some((gl::RGB, gl::RGB, gl::UNSIGNED_BYTE)),
     (Format::RGB(Size::Eight, Size::Eight, Size::Eight), Type::Integral) => Some((gl::RGB_INTEGER, gl::RGB8I, gl::BYTE)),
     (Format::RGB(Size::Eight, Size::Eight, Size::Eight), Type::Unsigned) => Some((gl::RGB_INTEGER, gl::RGB8UI, gl::UNSIGNED_BYTE)),
     (Format::RGB(Size::Sixteen, Size::Sixteen, Size::Sixteen), Type::Integral) => Some((gl::RGB_INTEGER, gl::RGB16I, gl::SHORT)),
@@ -622,6 +625,7 @@ pub(crate) fn opengl_pixel_format(pf: PixelFormat) -> Option<(GLenum, GLenum, GL
     (Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo), Type::Unsigned) => Some((gl::RGB_INTEGER, gl::RGB32UI, gl::UNSIGNED_INT)),
     (Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo), Type::Floating) => Some((gl::RGB, gl::RGB32F, gl::FLOAT)),
 
+    (Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight), Type::Floating) => Some((gl::RGBA, gl::RGBA, gl::UNSIGNED_BYTE)),
     (Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight), Type::Integral) => Some((gl::RGBA_INTEGER, gl::RGBA8I, gl::BYTE)),
     (Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight), Type::Unsigned) => Some((gl::RGBA_INTEGER, gl::RGBA8UI, gl::UNSIGNED_BYTE)),
     (Format::RGBA(Size::Sixteen, Size::Sixteen, Size::Sixteen, Size::Sixteen), Type::Integral) => Some((gl::RGBA_INTEGER, gl::RGBA16I, gl::SHORT)),


### PR DESCRIPTION
These four formats read from `GL_UNSIGNED_BYTE` and are accessed as `sampler2D` (float) in shaders.