### PR TITLE
Change TessGate::render so that it’s now polymorphic in the TessSlice…

### DIFF
--- a/luminance/CHANGELOG.md
+++ b/luminance/CHANGELOG.md
@@ -6,6 +6,9 @@
 
   - Swap the arguments in the binary closure that is passed to `ShadingGate::shade`. That is more
     logical regarding the other closures from, for instance, `Pipeline`.
+  - Change the `TessGate::render` function so that it now accepts `T: Into<TessSlice>`
+    instead of a `TessSlice` directly. That enables you to pass `&Tess` directly instead of
+    slicing it with `..` or `*_whole`.
 
 # 0.33
 

--- a/luminance/examples/01-hello-world-glutin.rs
+++ b/luminance/examples/01-hello-world-glutin.rs
@@ -253,7 +253,7 @@ fn main() {
             };
 
             // Render the tessellation to the surface.
-            tess_gate.render(&mut surface, tess.into());
+            tess_gate.render(&mut surface, tess);
           });
         });
       });

--- a/luminance/examples/01-hello-world.rs
+++ b/luminance/examples/01-hello-world.rs
@@ -230,7 +230,7 @@ fn main() {
             };
 
             // Render the tessellation to the surface.
-            tess_gate.render(&mut surface, tess.into());
+            tess_gate.render(&mut surface, tess);
           });
         });
       });

--- a/luminance/examples/02-render-state.rs
+++ b/luminance/examples/02-render-state.rs
@@ -125,13 +125,13 @@ fn main() {
 
           rdr_gate.render(render_state, |tess_gate| match depth_method {
             DepthMethod::Under => {
-              tess_gate.render(&mut surface, (&red_triangle).into());
-              tess_gate.render(&mut surface, (&blue_triangle).into());
+              tess_gate.render(&mut surface, &red_triangle);
+              tess_gate.render(&mut surface, &blue_triangle);
             }
 
             DepthMethod::Atop => {
-              tess_gate.render(&mut surface, (&blue_triangle).into());
-              tess_gate.render(&mut surface, (&red_triangle).into());
+              tess_gate.render(&mut surface, &blue_triangle);
+              tess_gate.render(&mut surface, &red_triangle);
             }
           });
         });

--- a/luminance/examples/04-shader-uniforms.rs
+++ b/luminance/examples/04-shader-uniforms.rs
@@ -123,7 +123,7 @@ fn main() {
 
           rdr_gate.render(RenderState::default(), |tess_gate| {
             // render the dynamically selected slice
-            tess_gate.render(&mut surface, (&triangle).into());
+            tess_gate.render(&mut surface, &triangle);
           });
         });
       });

--- a/luminance/examples/05-attributeless.rs
+++ b/luminance/examples/05-attributeless.rs
@@ -59,7 +59,7 @@ fn main() {
           rdr_gate.render(RenderState::default(), |tess_gate| {
             // render the tessellation to the surface the regular way and let the vertex shader’s
             // magic do the rest!
-            tess_gate.render(&mut surface, (&tess).into());
+            tess_gate.render(&mut surface, &tess);
           });
         });
       });

--- a/luminance/examples/06-texture.rs
+++ b/luminance/examples/06-texture.rs
@@ -103,7 +103,7 @@ fn run(texture_path: &Path) {
           rdr_gate.render(render_st, |tess_gate| {
             // render the tessellation to the surface the regular way and let the vertex shader’s
             // magic do the rest!
-            tess_gate.render(&mut surface, (&tess).into());
+            tess_gate.render(&mut surface, &tess);
           });
         });
       });

--- a/luminance/examples/08-shader-uniforms-adapt.rs
+++ b/luminance/examples/08-shader-uniforms-adapt.rs
@@ -160,7 +160,7 @@ fn main() {
               iface.triangle_size.update(t.cos().powf(2.));
 
               rdr_gate.render(RenderState::default(), |tess_gate| {
-                tess_gate.render(&mut surface, (&triangle).into());
+                tess_gate.render(&mut surface, &triangle);
               });
             });
           }
@@ -174,7 +174,7 @@ fn main() {
               iface.triangle_pos.update(triangle_pos);
 
               rdr_gate.render(RenderState::default(), |tess_gate| {
-                tess_gate.render(&mut surface, (&triangle).into());
+                tess_gate.render(&mut surface, &triangle);
               });
             });
           }

--- a/luminance/examples/09-dynamic-uniform-interface.rs
+++ b/luminance/examples/09-dynamic-uniform-interface.rs
@@ -121,7 +121,7 @@ fn main() {
           //}
 
           rdr_gate.render(RenderState::default(), |tess_gate| {
-            tess_gate.render(&mut surface, (&triangle).into());
+            tess_gate.render(&mut surface, &triangle);
           });
         });
       });

--- a/luminance/examples/10-vertex-instancing.rs
+++ b/luminance/examples/10-vertex-instancing.rs
@@ -114,7 +114,7 @@ fn main() {
           }
 
           rdr_gate.render(RenderState::default(), |tess_gate| {
-            tess_gate.render(&mut surface, (&triangle).into());
+            tess_gate.render(&mut surface, &triangle);
           });
         });
       });

--- a/luminance/examples/11-query-texture-texels.rs
+++ b/luminance/examples/11-query-texture-texels.rs
@@ -96,11 +96,9 @@ fn main() {
         shd_gate.shade(&program, |_,rdr_gate| {
           // start rendering things with the default render state provided by luminance
           rdr_gate.render(RenderState::default(), |tess_gate| {
-            let tess = &tris;
-
             // pick the right tessellation to use depending on the mode chosen
             // render the tessellation to the surface
-            tess_gate.render(&mut surface, tess.into());
+            tess_gate.render(&mut surface, &tris);
           });
         });
       });

--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -459,7 +459,7 @@ pub struct TessGate {
 
 impl TessGate {
   /// Render a tessellation.
-  pub fn render<C>(&self, ctx: &mut C, tess: TessSlice) where C: GraphicsContext {
-    tess.render(ctx);
+  pub fn render<'a, C, T>(&self, ctx: &mut C, tess: T) where C: GraphicsContext, T: Into<TessSlice<'a>> {
+    tess.into().render(ctx);
   }
 }


### PR DESCRIPTION
…. #197

It can now take T: Into<TessSlice>, allowing to pass references on Tess
for “whole” tessellations.