### PR TITLE
Add TessGate::builder(), to support dynamic Tess construction

### DIFF
--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -125,7 +125,7 @@ use crate::pixel::{Pixel, SamplerType, Type as PxType};
 use crate::render_state::RenderState;
 use crate::shader::program::{Program, ProgramInterface, Type, Uniform, UniformInterface, Uniformable};
 use crate::state::GraphicsState;
-use crate::tess::TessSlice;
+use crate::tess::{TessSlice, TessBuilder};
 use crate::texture::{Dim, Dimensionable, Layerable, Texture};
 use crate::vertex::Semantics;
 
@@ -469,7 +469,12 @@ pub struct TessGate<'a, C> where C: ?Sized {
   ctx: &'a mut C,
 }
 
-impl<'a, C> TessGate<'a, C> where C: ?Sized + GraphicsContext {
+impl<'a, C: Sized> TessGate<'a, C> where C: ?Sized + GraphicsContext {
+  /// Create a TessBuilder, borrowed against the GraphicsContext.
+  pub fn builder(&mut self) -> TessBuilder<C> {
+    TessBuilder::new(self.ctx)
+  }
+
   /// Render a tessellation.
   pub fn render<'b, T>(&'b mut self, tess: T) where T: Into<TessSlice<'b>> {
     tess.into().render(self.ctx);


### PR DESCRIPTION
This change adds TessGate::builder(), so you can dynamically create tesselations inside the TessGate callback.

I ran into a lot of lifetime issues on 0.35, and this seemed like the cleanest way to fix them.