### PR TITLE
Add ::new methods for user vertex types, so that they don’t have to do it.

### DIFF
--- a/bin/viewer/src/main.rs
+++ b/bin/viewer/src/main.rs
@@ -100,7 +100,7 @@ impl Obj {
             let n = object.normals[key.2.ok_or_else(|| "missing normal for a vertex".to_owned())?];
             let position = VPos::new([p.x as f32, p.y as f32, p.z as f32]);
             let normal = VNor::new([n.x as f32, n.y as f32, n.z as f32]);
-            let vertex = Vertex { position, normal };
+            let vertex = Vertex::new(position, normal);
             let vertex_index = vertices.len() as VertexIndex;
 
             vertex_cache.insert(*key, vertex_index);

--- a/luminance/examples/01-hello-world.rs
+++ b/luminance/examples/01-hello-world.rs
@@ -61,13 +61,13 @@ struct Vertex {
 // The vertices. We define two triangles.
 const TRI_VERTICES: [Vertex; 6] = [
   // First triangle – an RGB one.
-  Vertex { pos: VertexPosition::new([0.5, -0.5]), rgb: VertexColor::new([0, 255, 0]) },
-  Vertex { pos: VertexPosition::new([0.0, 0.5]), rgb: VertexColor::new([0, 0, 255]) },
-  Vertex { pos: VertexPosition::new([-0.5, -0.5]), rgb: VertexColor::new([255, 0, 0]) },
+  Vertex::new(VertexPosition::new([0.5, -0.5]), VertexColor::new([0, 255, 0])),
+  Vertex::new(VertexPosition::new([0.0, 0.5]), VertexColor::new([0, 0, 255])),
+  Vertex::new(VertexPosition::new([-0.5, -0.5]), VertexColor::new([255, 0, 0])),
   // Second triangle, a purple one, positioned differently.
-  Vertex { pos: VertexPosition::new([-0.5, 0.5]), rgb: VertexColor::new([255, 51, 255]) },
-  Vertex { pos: VertexPosition::new([0.0, -0.5]), rgb: VertexColor::new([51, 255, 255]) },
-  Vertex { pos: VertexPosition::new([0.5, 0.5]), rgb: VertexColor::new([51, 51, 255]) },
+  Vertex::new(VertexPosition::new([-0.5, 0.5]), VertexColor::new([255, 51, 255])),
+  Vertex::new(VertexPosition::new([0.0, -0.5]), VertexColor::new([51, 255, 255])),
+  Vertex::new(VertexPosition::new([0.5, 0.5]), VertexColor::new([51, 51, 255])),
 ];
 
 // A small struct wrapper used to deinterleave positions.


### PR DESCRIPTION
Fixes #194.