### PR TITLE
Re-export `glutin::MouseButton` in `luminance-glutin`

### DIFF
--- a/luminance-glutin/src/lib.rs
+++ b/luminance-glutin/src/lib.rs
@@ -8,7 +8,8 @@
 use gl;
 pub use glutin::{
   ContextError, CreationError, DeviceEvent, DeviceId, ElementState, Event, KeyboardInput,
-  ModifiersState, MouseScrollDelta, Touch, TouchPhase, VirtualKeyCode, WindowEvent, WindowId
+  ModifiersState, MouseScrollDelta, Touch, TouchPhase, VirtualKeyCode, WindowEvent, WindowId,
+  MouseButton
 };
 pub use glutin::dpi::{LogicalPosition, LogicalSize};
 pub use luminance_windowing::{CursorMode, Surface, WindowDim, WindowOpt};


### PR DESCRIPTION
This enum is used in `glutin::WindowEvent::MouseInput`, but `luminance-glutin` does not re-rexport it.