### PR TITLE
Grab & set position of cursor in luminance_glutin

### DIFF
--- a/luminance-glutin/Cargo.toml
+++ b/luminance-glutin/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 gl = "0.13"
-glutin = { version = "0.21", default-features = false }
+glutin = { version = "0.22.0-alpha5", default-features = false }
 luminance = "0.37"
 luminance-windowing = "0.8"
 

--- a/luminance-glutin/src/lib.rs
+++ b/luminance-glutin/src/lib.rs
@@ -108,10 +108,7 @@ impl Surface for GlutinSurface {
     // init OpenGL
     gl::load_with(|s| ctx.get_proc_address(s) as *const c_void);
 
-    match win_opt.cursor_mode() {
-      CursorMode::Visible => ctx.window().set_cursor_visible(true),
-      CursorMode::Invisible | CursorMode::Disabled => ctx.window().set_cursor_visible(false),
-    }
+    set_window_cursor_mode(ctx.window(), win_opt.cursor_mode());
 
     ctx.window().set_visible(true);
 
@@ -132,11 +129,7 @@ impl Surface for GlutinSurface {
   }
 
   fn set_cursor_mode(&mut self, mode: CursorMode) -> &mut Self {
-    match mode {
-      CursorMode::Visible => self.ctx.window().set_cursor_visible(true),
-      CursorMode::Invisible | CursorMode::Disabled => self.ctx.window().set_cursor_visible(false)
-    }
-
+    set_window_cursor_mode(self.ctx.window(), mode);
     self.opts = self.opts.set_cursor_mode(mode);
     self
   }
@@ -177,5 +170,24 @@ impl Surface for GlutinSurface {
 
   fn swap_buffers(&mut self) {
     self.ctx.swap_buffers().unwrap();
+  }
+}
+
+fn set_window_cursor_mode(window: &Window, mode: CursorMode) {
+  match mode {
+    CursorMode::Visible => {
+      window.set_cursor_visible(true);
+      window.set_cursor_grab(false).unwrap();
+    }
+    CursorMode::Invisible => {
+      window.set_cursor_visible(false);
+      window.set_cursor_grab(false).unwrap();
+    }
+    // glutin doesn’t support truly disabled cursors, but we can achieve
+    // something like it by hiding and grabbing the cursor.
+    CursorMode::Disabled => {
+      window.set_cursor_visible(false);
+      window.set_cursor_grab(true).unwrap();
+    }
   }
 }

--- a/luminance-glutin/src/lib.rs
+++ b/luminance-glutin/src/lib.rs
@@ -72,6 +72,13 @@ pub struct GlutinSurface {
   event_queue: Vec<Event<()>>
 }
 
+impl GlutinSurface {
+  /// Changes the position of the cursor in window coordinates
+  pub fn set_cursor_position(&self, pos: LogicalPosition) {
+    self.ctx.window().set_cursor_position(pos).unwrap();
+  }
+}
+
 unsafe impl GraphicsContext for GlutinSurface {
   fn state(&self) -> &Rc<RefCell<GraphicsState>> {
     &self.gfx_state


### PR DESCRIPTION
I needed to be able to grab and set the position of the cursor for a first-person camera in my application, so I implemented it here. This required an update to an alpha-version of glutin, so I don't know if it's appropriate to merge as-is, but I figured I'd submit a PR just in case.