### PR TITLE
Multiwin

### DIFF
--- a/luminance/Cargo.toml
+++ b/luminance/Cargo.toml
@@ -19,6 +19,8 @@ maintenance = { status = "actively-developed" }
 default = ["std"]
 std = ["gl"]
 
+multiwin = []
+
 [dependencies.gl]
 version = "0.14"
 optional = true

--- a/luminance/Cargo.toml
+++ b/luminance/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 default = ["std"]
 std = ["gl"]
 
-multiwin = []
+multi-contexts = []
 
 [dependencies.gl]
 version = "0.14"

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -116,6 +116,14 @@ impl GraphicsState {
     }
   }
 
+  /// Help swap from an opengl context to another
+  /// 
+  /// Note: currently it only run the same code as in new() method, but with no-std mode
+  #[cfg(feature = "std")]
+  pub fn swap_multi() -> Result<Self, StateQueryError> {
+    Self::get_from_context()
+  }
+
   /// Get a `GraphicsContext` from the current OpenGL context.
   pub(crate) fn get_from_context() -> Result<Self, StateQueryError> {
     unsafe {

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -123,8 +123,8 @@ impl GraphicsState {
   /// WARNING : you can use this method to bypass the new() unique context security, but
   /// it's a really bad idea, please consider this method as an advanced feature and use it
   /// with caution.
-  #[cfg(feature = "multiwin")]
-  pub fn new_multi() -> Result<Self, StateQueryError> {
+  #[cfg(feature = "multi-contexts")]
+  pub unsafe fn new_multi_contexts() -> Result<Self, StateQueryError> {
     Self::get_from_context()
   }
 

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -118,9 +118,13 @@ impl GraphicsState {
 
   /// Help swap from an opengl context to another
   /// 
-  /// Note: currently it only run the same code as in new() method, but with no-std mode
+  /// Note: currently it only run the same code as in new() method, but without the check
+  /// to the TLS to be sure that only one context exist in the thread
+  /// WARNING : you can use this method to bypass the new() unique context security, but
+  /// it's a really bad idea, please consider this method as an advanced feature and use it
+  /// with caution.
   #[cfg(feature = "std")]
-  pub fn swap_multi() -> Result<Self, StateQueryError> {
+  pub fn new_multi() -> Result<Self, StateQueryError> {
     Self::get_from_context()
   }
 

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -123,7 +123,7 @@ impl GraphicsState {
   /// WARNING : you can use this method to bypass the new() unique context security, but
   /// it's a really bad idea, please consider this method as an advanced feature and use it
   /// with caution.
-  #[cfg(feature = "std")]
+  #[cfg(feature = "multiwin")]
   pub fn new_multi() -> Result<Self, StateQueryError> {
     Self::get_from_context()
   }


### PR DESCRIPTION
Fix #295 

This pull request add a new method, `new_multi()` , to enable the multiple OpenGL contexts creation in one thread. See the PoC [nikut](https://github.com/othelarian/nikut) for a working example. The feature `multiwin` must be explicitly declare to enable the use of this new method.