### PR TITLE
Moving from ControlFlow::Poll to ControlFlow::Wait

### DIFF
--- a/luminance-examples/src/hello-world-glutin.rs
+++ b/luminance-examples/src/hello-world-glutin.rs
@@ -10,7 +10,7 @@
 
 use glutin::{
   dpi::PhysicalSize,
-  event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+  event::{ElementState, Event, KeyboardInput, StartCause, VirtualKeyCode, WindowEvent},
   event_loop::ControlFlow,
 };
 use luminance::context::GraphicsContext;
@@ -245,9 +245,9 @@ fn main() {
   println!("now rendering {:?}", demo);
 
   event_loop.run(move |event, _, control_flow| {
-    *control_flow = ControlFlow::Poll;
 
     match event {
+      Event::NewEvent(StartCause::Init) => *control_flow = ControlFlow::Wait,
       Event::WindowEvent { event, .. } => match event {
         // If we hit the spacebar, change the kind of tessellation.
         WindowEvent::KeyboardInput {


### PR DESCRIPTION
Multiple reason to change:

* if you put `*control_flow = ControlFlow::Poll` at the beginning of the loop it will be called everytime the loop is it
* by default the control_flow is in Poll mode [glutin doc ControlFlow](https://docs.rs/glutin/0.23.0/glutin/event_loop/enum.ControlFlow.html)
* Poll usage is for extensive used of redraw, like in video game, but this example only redraw when a keyboard input is hit, so `ControlFlow::Wait` is the recommended way to handle this kind of event loop (same link as above)

As describe in winit examples, using `Event::NewEvents(StartCause::Init)` is the recommended way to handle init configuration.