### PR TITLE
Implement std::error::Error if the "std" feature is enabled

### DIFF
--- a/luminance/src/buffer.rs
+++ b/luminance/src/buffer.rs
@@ -91,6 +91,8 @@ use std::cell::RefCell;
 #[cfg(feature = "std")]
 use std::cmp::Ordering;
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
 use std::marker::PhantomData;
@@ -175,6 +177,9 @@ impl fmt::Display for BufferError {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for BufferError {}
 
 /// A [`Buffer`] is a GPU region you can picture as an array.
 ///

--- a/luminance/src/framebuffer.rs
+++ b/luminance/src/framebuffer.rs
@@ -30,6 +30,8 @@
 
 #[cfg(feature = "std")]
 use std::cell::RefCell;
+#[cfg(feature = "std")]
+use std::error::Error;
 use std::fmt;
 #[cfg(feature = "std")]
 use std::marker::PhantomData;
@@ -74,6 +76,16 @@ impl fmt::Display for FramebufferError {
   }
 }
 
+#[cfg(feature = "std")]
+impl Error for FramebufferError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match *self {
+      FramebufferError::TextureError(ref e) => Some(e),
+      FramebufferError::Incomplete(ref e) => Some(e),
+    }
+  }
+}
+
 /// Reason a framebuffer is incomplete.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IncompleteReason {
@@ -109,6 +121,9 @@ impl fmt::Display for IncompleteReason {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for IncompleteReason {}
 
 /// Framebuffer with static layering, dimension, access and slots formats.
 ///

--- a/luminance/src/shader/program.rs
+++ b/luminance/src/shader/program.rs
@@ -29,6 +29,8 @@
 //! You can create a `Program` with its `new` associated function.
 
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::ffi::CString;
 #[cfg(feature = "std")]
 use std::fmt;
@@ -588,6 +590,18 @@ impl fmt::Display for ProgramError {
   }
 }
 
+#[cfg(feature = "std")]
+impl Error for ProgramError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match *self {
+      ProgramError::StageError(ref e) => Some(e),
+      ProgramError::UniformWarning(ref e) => Some(e),
+      ProgramError::VertexAttribWarning(ref e) => Some(e),
+      _ => None,
+    }
+  }
+}
+
 /// Program warnings, not necessarily considered blocking errors.
 #[derive(Debug)]
 pub enum ProgramWarning {
@@ -649,6 +663,9 @@ impl fmt::Display for UniformWarning {
   }
 }
 
+#[cfg(feature = "std")]
+impl Error for UniformWarning {}
+
 /// Warnings related to vertex attributes issues.
 #[derive(Debug)]
 pub enum VertexAttribWarning {
@@ -663,6 +680,9 @@ impl fmt::Display for VertexAttribWarning {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for VertexAttribWarning {}
 
 /// A contravariant shader uniform. `Uniform<T>` doesn’t hold any value. It’s more like a mapping
 /// between the host code and the shader the uniform was retrieved from.

--- a/luminance/src/shader/stage.rs
+++ b/luminance/src/shader/stage.rs
@@ -4,6 +4,8 @@
 //! _several_ shader stages. The minimal configuration implies at least a _vertex shader_ and a
 //! _fragment shader_.
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::ffi::CString;
 #[cfg(feature = "std")]
 use std::fmt;
@@ -147,6 +149,9 @@ impl fmt::Display for StageError {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for StageError {}
 
 fn glsl_pragma_src(src: &str) -> String {
   let mut pragma = String::from(GLSL_PRAGMA);

--- a/luminance/src/state.rs
+++ b/luminance/src/state.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "std")]
 use std::cell::RefCell;
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
 use std::marker::PhantomData;
@@ -496,6 +498,9 @@ impl fmt::Display for StateQueryError {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for StateQueryError {}
 
 unsafe fn get_ctx_viewport() -> Result<[GLint; 4], StateQueryError> {
   let mut data = [0; 4];

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -52,6 +52,8 @@
 //! [pipeline]: crate::pipeline
 
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
 use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
@@ -191,6 +193,17 @@ impl fmt::Display for TessMapError {
       TessMapError::ForbiddenDeinterleavedMapping => {
         f.write_str("cannot map a deinterleaved buffer as interleaved")
       }
+    }
+  }
+}
+
+#[cfg(feature = "std")]
+impl Error for TessMapError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match *self {
+      TessMapError::VertexBufferMapFailed(ref e) => Some(e),
+      TessMapError::IndexBufferMapFailed(ref e) => Some(e),
+      _ => None,
     }
   }
 }

--- a/luminance/src/texture.rs
+++ b/luminance/src/texture.rs
@@ -74,6 +74,8 @@
 #[cfg(feature = "std")]
 use std::cell::RefCell;
 #[cfg(feature = "std")]
+use std::error::Error;
+#[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
 use std::marker::PhantomData;
@@ -1342,3 +1344,6 @@ impl fmt::Display for TextureError {
     }
   }
 }
+
+#[cfg(feature = "std")]
+impl Error for TextureError {}


### PR DESCRIPTION
This PR basically restores `impl`s for `std::error::Error` that got omitted during commit 2f661e09fb8856c589cb7126855ee7562804b16c.