### PR TITLE
Add luminance-sdl2 backend.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxrandr-dev xorg-dev
+          sudo apt-get install -y libxrandr-dev xorg-dev libsdl2-dev
       - uses: actions/checkout@v1
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
   build-macosx:
     runs-on: macOS-latest
     steps:
+      - name: Install dependencies
+        run: brew install SDL2
       - uses: actions/checkout@v1
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "luminance-gl",
   "luminance-glfw",
   "luminance-glutin",
+  "luminance-sdl2",
   "luminance-webgl",
   "luminance-windowing",
 ]
@@ -18,4 +19,5 @@ luminance-examples = { path = "./luminance-examples" }
 luminance-gl = { path = "./luminance-gl" }
 luminance-glfw = { path = "./luminance-glfw" }
 luminance-glutin = { path = "./luminance-glutin" }
+luminance-sdl2 = { path = "./luminance-sdl2" }
 luminance-windowing = { path = "./luminance-windowing" }

--- a/luminance-sdl2/CHANGELOG.md
+++ b/luminance-sdl2/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1
+
+- Initial revision.

--- a/luminance-sdl2/Cargo.toml
+++ b/luminance-sdl2/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "luminance-sdl2"
+version = "0.1.0"
+license = "BSD-3-Clause"
+authors = [
+  "Dimitri Sabadie <dimitri.sabadie@gmail.com>",
+  "Joel Nordström <e.joel.nordstrom@gmail.com>"
+]
+description = "Sdl2 support for luminance"
+keywords = ["stateless", "type-safe", "graphics", "luminance", "sdl", "sdl2"]
+categories = ["rendering::graphics-api"]
+homepage = "https://github.com/phaazon/luminance-rs"
+repository = "https://github.com/phaazon/luminance-rs"
+documentation = "https://docs.rs/luminance-sdl2"
+readme = "README.md"
+edition = "2018"
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+gl = "0.14"
+luminance = "0.40"
+luminance-gl = "0.14"
+luminance-windowing = "0.9"
+sdl2 = "0.33"

--- a/luminance-sdl2/Cargo.toml
+++ b/luminance-sdl2/Cargo.toml
@@ -25,4 +25,4 @@ luminance-gl = "0.14"
 sdl2 = "0.33"
 
 [dev-dependencies]
-sdl2 = { features = ["bundled"] }
+sdl2 = { version = "0.33", features = ["bundled"] }

--- a/luminance-sdl2/Cargo.toml
+++ b/luminance-sdl2/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
   "Dimitri Sabadie <dimitri.sabadie@gmail.com>",
   "Joel Nordström <e.joel.nordstrom@gmail.com>"
 ]
-description = "Sdl2 support for luminance"
+description = "SDL2 support for luminance"
 keywords = ["stateless", "type-safe", "graphics", "luminance", "sdl", "sdl2"]
 categories = ["rendering::graphics-api"]
 homepage = "https://github.com/phaazon/luminance-rs"

--- a/luminance-sdl2/Cargo.toml
+++ b/luminance-sdl2/Cargo.toml
@@ -22,5 +22,4 @@ maintenance = { status = "actively-developed" }
 gl = "0.14"
 luminance = "0.40"
 luminance-gl = "0.14"
-luminance-windowing = "0.9"
 sdl2 = "0.33"

--- a/luminance-sdl2/Cargo.toml
+++ b/luminance-sdl2/Cargo.toml
@@ -23,3 +23,6 @@ gl = "0.14"
 luminance = "0.40"
 luminance-gl = "0.14"
 sdl2 = "0.33"
+
+[dev-dependencies]
+sdl2 = { features = ["bundled"] }

--- a/luminance-sdl2/LICENSE
+++ b/luminance-sdl2/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2020, Dimitri Sabadie <dimitri.sabadie@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Dimitri Sabadie <dimitri.sabadie@gmail.com> nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/luminance-sdl2/README.md
+++ b/luminance-sdl2/README.md
@@ -1,0 +1,8 @@
+# luminance-sdl2
+
+<!-- cargo-sync-readme start -->
+
+[SDL2](https://crates.io/crates/sdl2) backend for [luminance](https://crates.io/crates/luminance)
+and [luminance-windowing](https://crates.io/crates/luminance-windowing).
+
+<!-- cargo-sync-readme end -->

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -58,7 +58,7 @@ impl fmt::Display for Sdl2SurfaceError {
 /// let surface = GL33Surface::build_with(|video| video.window("My app", 800, 600))
 ///     .expect("failed to create surface");
 ///
-/// let sdl: sdl2::Sdl = surface.sdl();
+/// let sdl = surface.sdl();
 /// ```
 ///
 /// [luminance]: https://crates.io/crates/luminance

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -52,7 +52,7 @@ impl fmt::Display for Sdl2SurfaceError {
 
 /// A [luminance] GraphicsContext backed by SDL2 and OpenGL 3.3 Core.
 ///
-/// ```
+/// ```ignore
 /// use luminance_sdl2::GL33Surface;
 ///
 /// let surface = GL33Surface::build_with(|video| video.window("My app", 800, 600))
@@ -77,7 +77,7 @@ impl GL33Surface {
   /// This is your chance to change GL attributes before creating the window with your preferred
   /// settings.
   ///
-  /// ```
+  /// ```ignore
   /// use luminance_sdl2::GL33Surface;
   ///
   /// let surface = GL33Surface::build_with(|video| {

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -36,25 +36,16 @@ pub enum Sdl2SurfaceError {
 impl fmt::Display for Sdl2SurfaceError {
   fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     match *self {
-      Sdl2SurfaceError::InitError(ref e) => {
-        f.write_str("initialization error: ")?;
-        e.fmt(f)
-      }
-      Sdl2SurfaceError::WindowCreationFailed(ref e) => {
-        f.write_str("failed to create window: ")?;
-        e.fmt(f)
-      }
+      Sdl2SurfaceError::InitError(ref e) => write!(f, "initialization error: {}", e),
+      Sdl2SurfaceError::WindowCreationFailed(ref e) => write!(f, "failed to create window: {}", e),
       Sdl2SurfaceError::GlContextInitFailed(ref e) => {
-        f.write_str("failed to create OpenGL context: ")?;
-        e.fmt(f)
+        write!(f, "failed to create OpenGL context: {}", e)
       }
       Sdl2SurfaceError::VideoInitError(ref e) => {
-        f.write_str("failed to initialize video system: ")?;
-        e.fmt(f)
+        write!(f, "failed to initialize video system: {}", e)
       }
       Sdl2SurfaceError::GraphicsStateError(ref e) => {
-        f.write_str("failed to get graphics state: ")?;
-        e.fmt(f)
+        write!(f, "failed to get graphics state: {}", e)
       }
     }
   }

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -51,7 +51,7 @@ impl fmt::Display for Sdl2SurfaceError {
   }
 }
 
-/// A [luminance] GraphicsContext backed by Sdl2 and OpenGL 3.3 Core.
+/// A [luminance] GraphicsContext backed by SDL2 and OpenGL 3.3 Core.
 ///
 /// ```
 /// use luminance_sdl2::{GL33Surface, WindowOpt, WindowDim, CursorMode};
@@ -156,12 +156,12 @@ impl GL33Surface {
     Ok(surface)
   }
 
-  /// The entry point to most of the Sdl2 API.
+  /// The entry point to most of the SDL2 API.
   pub fn sdl(&self) -> &sdl2::Sdl {
     &self.sdl
   }
 
-  /// The underlying Sdl2 window of this surface.
+  /// The underlying SDL2 window of this surface.
   pub fn window(&self) -> &sdl2::video::Window {
     &self.window
   }

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -1,0 +1,191 @@
+//! [SDL2](https://crates.io/crates/sdl2) backend for [luminance](https://crates.io/crates/luminance)
+//! and [luminance-windowing](https://crates.io/crates/luminance-windowing).
+
+#![deny(missing_docs)]
+
+use gl;
+use luminance::context::GraphicsContext;
+use luminance::framebuffer::Framebuffer;
+use luminance::framebuffer::FramebufferError;
+use luminance::texture::Dim2;
+pub use luminance_gl::gl33::StateQueryError;
+use luminance_gl::GL33;
+pub use luminance_windowing::{CursorMode, WindowDim, WindowOpt};
+pub use sdl2;
+use std::fmt;
+use std::os::raw::c_void;
+
+/// Error that can be risen while creating a surface.
+#[derive(Debug)]
+pub enum Sdl2SurfaceError {
+  /// Initialization of the surface went wrong.
+  InitError(String),
+  /// Window creation failed.
+  WindowCreationFailed(sdl2::video::WindowBuildError),
+  /// Failed to create an OpenGL context.
+  GlContextInitFailed(String),
+  /// No available video mode.
+  VideoInitError(String),
+  /// The graphics state is not available.
+  ///
+  /// This error is generated when the initialization code is called on a thread on which the
+  /// graphics state has already been acquired.
+  GraphicsStateError(StateQueryError),
+}
+
+impl fmt::Display for Sdl2SurfaceError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match *self {
+      Sdl2SurfaceError::InitError(ref e) => {
+        f.write_str("initialization error: ")?;
+        e.fmt(f)
+      }
+      Sdl2SurfaceError::WindowCreationFailed(ref e) => {
+        f.write_str("failed to create window: ")?;
+        e.fmt(f)
+      }
+      Sdl2SurfaceError::GlContextInitFailed(ref e) => {
+        f.write_str("failed to create OpenGL context: ")?;
+        e.fmt(f)
+      }
+      Sdl2SurfaceError::VideoInitError(ref e) => {
+        f.write_str("failed to initialize video system: ")?;
+        e.fmt(f)
+      }
+      Sdl2SurfaceError::GraphicsStateError(ref e) => {
+        f.write_str("failed to get graphics state: ")?;
+        e.fmt(f)
+      }
+    }
+  }
+}
+
+/// A [luminance] GraphicsContext backed by Sdl2 and OpenGL 3.3 Core.
+///
+/// ```
+/// use luminance_sdl2::{GL33Surface, WindowOpt, WindowDim, CursorMode};
+///
+/// let opts = WindowOpt::default()
+///     .set_dim(WindowDim::Fullscreen)
+///     .set_cursor_mode(CursorMode::Disabled);
+///
+/// let surface = GL33Surface::new("Example window", opts)
+///     .expect("failed to create surface");
+///
+/// let event_pump = surface.sdl().event_pump()
+///     .expect("failed to initialize event subsystem");
+/// ```
+///
+/// [luminance]: https://crates.io/crates/luminance
+pub struct GL33Surface {
+  sdl: sdl2::Sdl,
+  window: sdl2::video::Window,
+  gl: GL33,
+  // This struct needs to stay alive until we are done with OpenGL stuff.
+  _gl_context: sdl2::video::GLContext,
+}
+
+impl GL33Surface {
+  /// Create a new surface.
+  pub fn new(title: &str, options: WindowOpt) -> Result<Self, Sdl2SurfaceError> {
+    let sdl = sdl2::init().map_err(Sdl2SurfaceError::InitError)?;
+
+    let video_system = sdl.video().map_err(Sdl2SurfaceError::VideoInitError)?;
+
+    let gl_attr = video_system.gl_attr();
+
+    gl_attr.set_context_profile(sdl2::video::GLProfile::Core);
+    gl_attr.set_context_flags().forward_compatible().set();
+    gl_attr.set_context_major_version(3);
+    gl_attr.set_context_minor_version(3);
+
+    match options.num_samples {
+      Some(num) => {
+        gl_attr.set_multisample_buffers(1);
+        gl_attr.set_multisample_samples(num as u8);
+      }
+      None => {
+        gl_attr.set_multisample_buffers(0);
+        gl_attr.set_multisample_samples(0);
+      }
+    }
+
+    let mouse = sdl.mouse();
+    match options.cursor_mode {
+      CursorMode::Visible => {
+        mouse.show_cursor(true);
+        mouse.set_relative_mouse_mode(false);
+      }
+      CursorMode::Invisible => {
+        mouse.show_cursor(false);
+        mouse.set_relative_mouse_mode(false);
+      }
+      CursorMode::Disabled => {
+        mouse.show_cursor(false);
+        mouse.set_relative_mouse_mode(true);
+      }
+    }
+
+    let window = {
+      let mut builder;
+      match options.dim {
+        WindowDim::Windowed { width, height } => {
+          builder = video_system.window(title, width, height)
+        }
+        WindowDim::Fullscreen => {
+          // I don't think it matters what dimensions we pass here.
+          builder = video_system.window(title, 800, 600);
+          builder.fullscreen();
+        }
+        WindowDim::FullscreenRestricted { width, height } => {
+          builder = video_system.window(title, width, height);
+          builder.fullscreen_desktop();
+        }
+      }
+      builder
+        .opengl()
+        .build()
+        .map_err(Sdl2SurfaceError::WindowCreationFailed)?
+    };
+
+    let _gl_context = window
+      .gl_create_context()
+      .map_err(Sdl2SurfaceError::GlContextInitFailed)?;
+
+    gl::load_with(|s| video_system.gl_get_proc_address(s) as *const c_void);
+
+    let gl = GL33::new().map_err(Sdl2SurfaceError::GraphicsStateError)?;
+    let surface = GL33Surface {
+      sdl,
+      window,
+      gl,
+      _gl_context,
+    };
+
+    Ok(surface)
+  }
+
+  /// The entry point to most of the Sdl2 API.
+  pub fn sdl(&self) -> &sdl2::Sdl {
+    &self.sdl
+  }
+
+  /// The underlying Sdl2 window of this surface.
+  pub fn window(&self) -> &sdl2::video::Window {
+    &self.window
+  }
+
+  /// Get the back buffer.
+  pub fn back_buffer(&mut self) -> Result<Framebuffer<GL33, Dim2, (), ()>, FramebufferError> {
+    let (w, h) = self.window.drawable_size();
+    Framebuffer::back_buffer(self, [w, h])
+  }
+}
+
+unsafe impl GraphicsContext for GL33Surface {
+  type Backend = GL33;
+
+  fn backend(&mut self) -> &mut Self::Backend {
+    &mut self.gl
+  }
+}

--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::os::raw::c_void;
 
 /// Error that can be risen while creating a surface.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Sdl2SurfaceError {
   /// Initialization of the surface went wrong.
@@ -92,7 +93,7 @@ impl GL33Surface {
   /// ```
   pub fn build_with<WB>(window_builder: WB) -> Result<Self, Sdl2SurfaceError>
   where
-      WB: FnOnce(&sdl2::VideoSubsystem) -> sdl2::video::WindowBuilder,
+    WB: FnOnce(&sdl2::VideoSubsystem) -> sdl2::video::WindowBuilder,
   {
     let sdl = sdl2::init().map_err(Sdl2SurfaceError::InitError)?;
 


### PR DESCRIPTION
I've been using luminance with sdl2 for a while now and I think it works great. I thought I'd share what I built, but I didn't realize you had this massive 0.40 rewrite on the way.
I rewrote the Sdl2Surface to my best understanding of the new architecture, but I haven't ported my game to 0.40 yet, so I haven't really tested this incarnation of the surface. I figured I might as well open the PR now, and mark it as ready once I've confirmed it still works.