### PR TITLE
API simplification

### DIFF
--- a/luminance-examples/src/attributeless.rs
+++ b/luminance-examples/src/attributeless.rs
@@ -12,9 +12,7 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
 use luminance::tess::Mode;
-use luminance::tess::TessBuilder;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
 
@@ -33,13 +31,16 @@ fn main() {
   .expect("GLFW surface creation");
 
   // we don’t use a Vertex type anymore (i.e. attributeless, so we use the unit () type)
-  let mut program = Program::<_, (), (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<(), (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // yet, we still need to tell luminance to render a certain number of vertices (even if we send no
   // attributes / data); in our case, we’ll just render a triangle, which has three vertices
-  let tess = TessBuilder::new(&mut surface)
+  let tess = surface
+    .new_tess()
     .and_then(|b| b.set_vertex_nb(3))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/displacement-map.rs
+++ b/luminance-examples/src/displacement-map.rs
@@ -21,9 +21,9 @@ use luminance::context::GraphicsContext;
 use luminance::pipeline::{PipelineState, TextureBinding};
 use luminance::pixel::{NormRGB8UI, NormUnsigned};
 use luminance::render_state::RenderState;
-use luminance::shader::{Program, Uniform};
-use luminance::tess::{Mode, TessBuilder};
-use luminance::texture::{Dim2, GenMipmaps, Sampler, Texture};
+use luminance::shader::Uniform;
+use luminance::tess::Mode;
+use luminance::texture::{Dim2, GenMipmaps, Sampler};
 use luminance_derive::UniformInterface;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
@@ -76,33 +76,35 @@ fn main() {
   .expect("Could not create GLFW surface");
 
   let texels = texture_image.into_raw();
-  let mut tex =
-    Texture::<_, Dim2, NormRGB8UI>::new(&mut surface, [width, height], 0, Sampler::default())
-      .expect("Could not create luminance texture");
+  let mut tex = surface
+    .new_texture::<Dim2, NormRGB8UI>([width, height], 0, Sampler::default())
+    .expect("Could not create luminance texture");
   tex.upload_raw(GenMipmaps::No, &texels).unwrap();
 
   let texels = displacement_map_1.into_raw();
-  let mut displacement_tex_1 =
-    Texture::<_, Dim2, NormRGB8UI>::new(&mut surface, [128, 128], 0, Sampler::default())
-      .expect("Could not create luminance texture");
+  let mut displacement_tex_1 = surface
+    .new_texture::<Dim2, NormRGB8UI>([128, 128], 0, Sampler::default())
+    .expect("Could not create luminance texture");
   displacement_tex_1
     .upload_raw(GenMipmaps::No, &texels)
     .unwrap();
 
   let texels = displacement_map_2.into_raw();
-  let mut displacement_tex_2 =
-    Texture::<_, Dim2, NormRGB8UI>::new(&mut surface, [101, 101], 0, Sampler::default())
-      .expect("Could not create luminance texture");
+  let mut displacement_tex_2 = surface
+    .new_texture::<Dim2, NormRGB8UI>([101, 101], 0, Sampler::default())
+    .expect("Could not create luminance texture");
   displacement_tex_2
     .upload_raw(GenMipmaps::No, &texels)
     .unwrap();
 
-  let mut program =
-    Program::<_, (), (), ShaderInterface>::from_strings(&mut surface, VS, None, None, FS)
-      .expect("Could not create shader program")
-      .ignore_warnings();
+  let mut program = surface
+    .new_shader_program::<(), (), ShaderInterface>()
+    .from_strings(VS, None, None, FS)
+    .expect("Could not create shader program")
+    .ignore_warnings();
 
-  let tess = TessBuilder::new(&mut surface)
+  let tess = surface
+    .new_tess()
     .and_then(|b| b.set_vertex_nb(4))
     .and_then(|b| b.set_mode(Mode::TriangleFan))
     .and_then(|b| b.build())

--- a/luminance-examples/src/dynamic-uniform-interface.rs
+++ b/luminance-examples/src/dynamic-uniform-interface.rs
@@ -20,8 +20,7 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
 use std::time::Instant;
@@ -57,11 +56,14 @@ fn main() {
   .expect("GLFW surface creation");
 
   // notice that we don’t set a uniform interface here: we’re going to look it up on the fly
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
-  let triangle = TessBuilder::new(&mut surface)
+  let triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/hello-world-glutin.rs
+++ b/luminance-examples/src/hello-world-glutin.rs
@@ -16,8 +16,7 @@ use glutin::{
 use luminance::context::GraphicsContext;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_derive::{Semantics, Vertex};
 use luminance_glutin::GlutinSurface;
 
@@ -197,13 +196,16 @@ fn main() {
 
   // We need a program to “shade” our triangles and to tell luminance which is the input vertex
   // type, and we’re not interested in the other two type variables for this sample.
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // Create tessellation for direct geometry; that is, tessellation that will render vertices by
   // taking one after another in the provided slice.
-  let direct_triangles = TessBuilder::new(&mut surface)
+  let direct_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())
@@ -212,7 +214,8 @@ fn main() {
   // Create indexed tessellation; that is, the vertices will be picked by using the indexes provided
   // by the second slice and this indexes will reference the first slice (useful not to duplicate
   // vertices on more complex objects than just two triangles).
-  let indexed_triangles = TessBuilder::new(&mut surface)
+  let indexed_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_indices(TRI_INDICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
@@ -221,7 +224,8 @@ fn main() {
 
   // Create direct, deinterleaved tesselations; such tessellations allow to separate vertex
   // attributes in several contiguous regions of memory.
-  let direct_deinterleaved_triangles = TessBuilder::new(&mut surface)
+  let direct_deinterleaved_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_DEINT_POS_VERTICES))
     .and_then(|b| b.add_vertices(TRI_DEINT_COLOR_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
@@ -229,7 +233,8 @@ fn main() {
     .unwrap();
 
   // Create indexed, deinterleaved tessellations; have your cake and fucking eat it, now.
-  let indexed_deinterleaved_triangles = TessBuilder::new(&mut surface)
+  let indexed_deinterleaved_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_DEINT_POS_VERTICES))
     .and_then(|b| b.add_vertices(TRI_DEINT_COLOR_VERTICES))
     .and_then(|b| b.set_indices(TRI_INDICES))

--- a/luminance-examples/src/hello-world.rs
+++ b/luminance-examples/src/hello-world.rs
@@ -192,10 +192,6 @@ fn main() {
   // We need a program to “shade” our triangles and to tell luminance which is the input vertex
   // type, and we’re not interested in the other two type variables for this sample.
 
-  // let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
-  //   .expect("program creation")
-  //   .ignore_warnings();
-
   let mut program = surface
     .new_shader_program::<Semantics, (), ()>()
     .from_strings(VS, None, None, FS)

--- a/luminance-examples/src/hello-world.rs
+++ b/luminance-examples/src/hello-world.rs
@@ -12,8 +12,7 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_derive::{Semantics, Vertex};
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
@@ -192,13 +191,21 @@ fn main() {
 
   // We need a program to “shade” our triangles and to tell luminance which is the input vertex
   // type, and we’re not interested in the other two type variables for this sample.
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+
+  // let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  //   .expect("program creation")
+  //   .ignore_warnings();
+
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // Create tessellation for direct geometry; that is, tessellation that will render vertices by
   // taking one after another in the provided slice.
-  let direct_triangles = TessBuilder::new(&mut surface)
+  let direct_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())
@@ -207,7 +214,8 @@ fn main() {
   // Create indexed tessellation; that is, the vertices will be picked by using the indexes provided
   // by the second slice and this indexes will reference the first slice (useful not to duplicate
   // vertices on more complex objects than just two triangles).
-  let indexed_triangles = TessBuilder::new(&mut surface)
+  let indexed_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_indices(TRI_INDICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
@@ -216,7 +224,8 @@ fn main() {
 
   // Create direct, deinterleaved tesselations; such tessellations allow to separate vertex
   // attributes in several contiguous regions of memory.
-  let direct_deinterleaved_triangles = TessBuilder::new(&mut surface)
+  let direct_deinterleaved_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_DEINT_POS_VERTICES))
     .and_then(|b| b.add_vertices(TRI_DEINT_COLOR_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
@@ -224,7 +233,8 @@ fn main() {
     .unwrap();
 
   // Create indexed, deinterleaved tessellations; have your cake and fucking eat it, now.
-  let indexed_deinterleaved_triangles = TessBuilder::new(&mut surface)
+  let indexed_deinterleaved_triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_DEINT_POS_VERTICES))
     .and_then(|b| b.add_vertices(TRI_DEINT_COLOR_VERTICES))
     .and_then(|b| b.set_indices(TRI_INDICES))

--- a/luminance-examples/src/query-texture-texels.rs
+++ b/luminance-examples/src/query-texture-texels.rs
@@ -11,12 +11,10 @@ use crate::common::{Semantics, Vertex, VertexColor, VertexPosition};
 use glfw::{Action, Context as _, Key, WindowEvent};
 use image::{save_buffer, ColorType};
 use luminance::context::GraphicsContext as _;
-use luminance::framebuffer::Framebuffer;
 use luminance::pipeline::PipelineState;
 use luminance::pixel::NormRGBA8UI;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance::texture::{Dim2, Sampler};
 use luminance_derive::Vertex;
 use luminance_glfw::GlfwSurface;
@@ -84,13 +82,16 @@ fn main() {
 
   // we need a program to “shade” our triangles and to tell luminance which is the input vertex
   // type, and we’re not interested in the other two type variables for this sample
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // create tessellation for direct geometry; that is, tessellation that will render vertices by
   // taking one after another in the provided slice
-  let tris = TessBuilder::new(&mut surface)
+  let tris = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())
@@ -101,9 +102,9 @@ fn main() {
 
   // the back buffer, which we will make our render into (we make it mutable so that we can change
   // it whenever the window dimensions change)
-  let mut fb =
-    Framebuffer::<_, Dim2, NormRGBA8UI, ()>::new(&mut surface, [960, 540], 0, Sampler::default())
-      .unwrap();
+  let mut fb = surface
+    .new_framebuffer::<Dim2, NormRGBA8UI, ()>([960, 540], 0, Sampler::default())
+    .unwrap();
 
   'app: loop {
     // for all the events on the surface

--- a/luminance-examples/src/render-state.rs
+++ b/luminance-examples/src/render-state.rs
@@ -17,8 +17,7 @@ use luminance::blending::{Blending, Equation, Factor};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
 
@@ -93,17 +92,21 @@ fn main() {
   )
   .expect("GLFW surface creation");
 
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // create a red and blue triangles
-  let red_triangle = TessBuilder::new(&mut surface)
+  let red_triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(&TRI_RED_BLUE_VERTICES[0..3]))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())
     .unwrap();
-  let blue_triangle = TessBuilder::new(&mut surface)
+  let blue_triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(&TRI_RED_BLUE_VERTICES[3..6]))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/shader-uniforms-adapt.rs
+++ b/luminance-examples/src/shader-uniforms-adapt.rs
@@ -23,7 +23,7 @@ use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
 use luminance::shader::{AdaptationFailure, Program, Uniform};
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_derive::UniformInterface;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
@@ -114,12 +114,15 @@ fn main() {
   .expect("GLFW surface creation");
 
   let mut program = ProgramMode::First(
-    Program::<_, Semantics, (), ShaderInterface1>::from_strings(&mut surface, VS, None, None, FS)
+    surface
+      .new_shader_program::<Semantics, (), ShaderInterface1>()
+      .from_strings(VS, None, None, FS)
       .expect("program creation")
       .ignore_warnings(),
   );
 
-  let triangle = TessBuilder::new(&mut surface)
+  let triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/shader-uniforms.rs
+++ b/luminance-examples/src/shader-uniforms.rs
@@ -18,8 +18,8 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::{Program, Uniform};
-use luminance::tess::{Mode, TessBuilder};
+use luminance::shader::Uniform;
+use luminance::tess::Mode;
 use luminance_derive::UniformInterface;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
@@ -67,12 +67,14 @@ fn main() {
   .expect("GLFW surface creation");
 
   // see the use of our uniform interface here as thirds type variable
-  let mut program =
-    Program::<_, Semantics, (), ShaderInterface>::from_strings(&mut surface, VS, None, None, FS)
-      .expect("program creation")
-      .ignore_warnings();
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ShaderInterface>()
+    .from_strings(VS, None, None, FS)
+    .expect("program creation")
+    .ignore_warnings();
 
-  let triangle = TessBuilder::new(&mut surface)
+  let triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/sliced-tess.rs
+++ b/luminance-examples/src/sliced-tess.rs
@@ -21,8 +21,7 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
-use luminance::tess::{Mode, SubTess, TessBuilder};
+use luminance::tess::{Mode, SubTess};
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
 
@@ -87,12 +86,15 @@ fn main() {
   )
   .expect("GLFW surface creation");
 
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
   // create a single GPU tessellation that holds both the triangles (like in 01-hello-world)
-  let triangles = TessBuilder::new(&mut surface)
+  let triangles = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_RED_BLUE_VERTICES))
     .and_then(|b| b.set_mode(Mode::Triangle))
     .and_then(|b| b.build())

--- a/luminance-examples/src/texture.rs
+++ b/luminance-examples/src/texture.rs
@@ -18,8 +18,8 @@ use luminance::context::GraphicsContext;
 use luminance::pipeline::{PipelineState, TextureBinding};
 use luminance::pixel::{NormRGB8UI, NormUnsigned};
 use luminance::render_state::RenderState;
-use luminance::shader::{Program, Uniform};
-use luminance::tess::{Mode, TessBuilder};
+use luminance::shader::Uniform;
+use luminance::tess::Mode;
 use luminance::texture::{Dim2, GenMipmaps, Sampler, Texture};
 use luminance_derive::UniformInterface;
 use luminance_glfw::GlfwSurface;
@@ -58,15 +58,17 @@ fn run(texture_path: &Path) {
   let mut tex = load_from_disk(&mut surface, img);
 
   // set the uniform interface to our type so that we can read textures from the shader
-  let mut program =
-    Program::<_, (), (), ShaderInterface>::from_strings(&mut surface, VS, None, None, FS)
-      .expect("program creation")
-      .ignore_warnings();
+  let mut program = surface
+    .new_shader_program::<(), (), ShaderInterface>()
+    .from_strings(VS, None, None, FS)
+    .expect("program creation")
+    .ignore_warnings();
 
   // we’ll use an attributeless render here to display a quad on the screen (two triangles); there
   // are over ways to cover the whole screen but this is easier for you to understand; the
   // TriangleFan creates triangles by connecting the third (and next) vertex to the first one
-  let tess = TessBuilder::new(&mut surface)
+  let tess = surface
+    .new_tess()
     .and_then(|b| b.set_vertex_nb(4))
     .and_then(|b| b.set_mode(Mode::TriangleFan))
     .and_then(|b| b.build())

--- a/luminance-examples/src/vertex-instancing.rs
+++ b/luminance-examples/src/vertex-instancing.rs
@@ -13,7 +13,6 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::shader::Program;
 use luminance::tess::{Mode, TessBuilder};
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};

--- a/luminance-examples/src/vertex-instancing.rs
+++ b/luminance-examples/src/vertex-instancing.rs
@@ -13,7 +13,7 @@ use glfw::{Action, Context as _, Key, WindowEvent};
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
 use luminance::render_state::RenderState;
-use luminance::tess::{Mode, TessBuilder};
+use luminance::tess::Mode;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{WindowDim, WindowOpt};
 use std::time::Instant;
@@ -73,11 +73,14 @@ fn main() {
   .expect("GLFW surface creation");
 
   // notice that we don’t set a uniform interface here: we’re going to look it up on the fly
-  let mut program = Program::<_, Semantics, (), ()>::from_strings(&mut surface, VS, None, None, FS)
+  let mut program = surface
+    .new_shader_program::<Semantics, (), ()>()
+    .from_strings(VS, None, None, FS)
     .expect("program creation")
     .ignore_warnings();
 
-  let triangle = TessBuilder::new(&mut surface)
+  let triangle = surface
+    .new_tess()
     .and_then(|b| b.add_vertices(TRI_VERTICES))
     .and_then(|b| b.add_instances(INSTANCES))
     .and_then(|b| b.set_mode(Mode::Triangle))

--- a/luminance/src/context.rs
+++ b/luminance/src/context.rs
@@ -54,10 +54,7 @@ use crate::buffer::{Buffer, BufferError};
 use crate::framebuffer::{Framebuffer, FramebufferError};
 use crate::pipeline::PipelineGate;
 use crate::pixel::Pixel;
-use crate::shader::{
-  BuiltProgram, Program, ProgramError, Stage, StageError, StageType, TessellationStages,
-  UniformInterface,
-};
+use crate::shader::{ProgramBuilder, Stage, StageError, StageType};
 use crate::tess::{TessBuilder, TessError};
 use crate::texture::{Dimensionable, Sampler, Texture, TextureError};
 use crate::vertex::Semantics;
@@ -155,88 +152,13 @@ pub unsafe trait GraphicsContext: Sized {
 
   /// Create a new shader program.
   ///
-  /// See the documentation of [`Program::from_stages_env`] for further details.
-  fn new_shader_program_from_stages_env<'a, Sem, Out, Uni, T, G, E>(
-    &mut self,
-    vertex: &'a Stage<Self::Backend>,
-    tess: T,
-    geometry: G,
-    fragment: &'a Stage<Self::Backend>,
-    env: &mut E,
-  ) -> Result<BuiltProgram<Self::Backend, Sem, Out, Uni>, ProgramError>
+  /// See the documentation of [`ProgramBuilder::new`] for further details.
+  fn new_shader_program<Sem, Out, Uni>(&mut self) -> ProgramBuilder<Self, Sem, Out, Uni>
   where
     Self::Backend: Shader,
     Sem: Semantics,
-    Uni: UniformInterface<Self::Backend, E>,
-    T: Into<Option<TessellationStages<'a, Stage<Self::Backend>>>>,
-    G: Into<Option<&'a Stage<Self::Backend>>>,
   {
-    Program::from_stages_env(self, vertex, tess, geometry, fragment, env)
-  }
-
-  /// Create a new shader program.
-  ///
-  /// See the documentation of [`Program::from_stages`] for further details.
-  fn new_shader_program_from_stages<Sem, Out, Uni, T, G>(
-    &mut self,
-    vertex: &Stage<Self::Backend>,
-    tess: T,
-    geometry: G,
-    fragment: &Stage<Self::Backend>,
-  ) -> Result<BuiltProgram<Self::Backend, Sem, Out, Uni>, ProgramError>
-  where
-    Self::Backend: Shader,
-    Uni: UniformInterface<Self::Backend>,
-    Sem: Semantics,
-    T: for<'a> Into<Option<TessellationStages<'a, Stage<Self::Backend>>>>,
-    G: for<'a> Into<Option<&'a Stage<Self::Backend>>>,
-  {
-    Program::from_stages(self, vertex, tess, geometry, fragment)
-  }
-
-  /// Create a new shader program.
-  ///
-  /// See the documentation of [`Program::from_strings_env`] for further details.
-  fn new_shader_program_from_strings_env<'a, Sem, Out, Uni, V, T, G, F, E>(
-    &mut self,
-    vertex: V,
-    tess: T,
-    geometry: G,
-    fragment: F,
-    env: &mut E,
-  ) -> Result<BuiltProgram<Self::Backend, Sem, Out, Uni>, ProgramError>
-  where
-    Self::Backend: Shader,
-    Sem: Semantics,
-    Uni: UniformInterface<Self::Backend, E>,
-    V: AsRef<str> + 'a,
-    T: Into<Option<TessellationStages<'a, str>>>,
-    G: Into<Option<&'a str>>,
-    F: AsRef<str> + 'a,
-  {
-    Program::from_strings_env(self, vertex, tess, geometry, fragment, env)
-  }
-
-  /// Create a new shader program.
-  ///
-  /// See the documentation of [`Program::from_strings`] for further details.
-  fn new_shader_program_from_strings<'a, Sem, Out, Uni, V, T, G, F>(
-    &mut self,
-    vertex: V,
-    tess: T,
-    geometry: G,
-    fragment: F,
-  ) -> Result<BuiltProgram<Self::Backend, Sem, Out, Uni>, ProgramError>
-  where
-    Self::Backend: Shader,
-    Sem: Semantics,
-    Uni: UniformInterface<Self::Backend>,
-    V: AsRef<str> + 'a,
-    T: Into<Option<TessellationStages<'a, str>>>,
-    G: Into<Option<&'a str>>,
-    F: AsRef<str> + 'a,
-  {
-    Program::from_strings(self, vertex, tess, geometry, fragment)
+    ProgramBuilder::new(self)
   }
 
   /// Create a [`TessBuilder`].

--- a/luminance/src/context.rs
+++ b/luminance/src/context.rs
@@ -164,7 +164,7 @@ pub unsafe trait GraphicsContext: Sized {
   /// Create a [`TessBuilder`].
   ///
   /// See the documentation of [`TessBuilder::new`] for further details.
-  fn new_tess_builder(&mut self) -> Result<TessBuilder<Self::Backend>, TessError>
+  fn new_tess(&mut self) -> Result<TessBuilder<Self::Backend>, TessError>
   where
     Self::Backend: TessBuilderBackend,
   {


### PR DESCRIPTION
# Foreword

This change set provides a nicer user experience that reduces the number of type variables they have to deal with, passing objects and importing types for several types (among shaders and tessellations).

# Content

The PR is made out of two parts:

- Two commits that update the API (API hygiene).
- One commit that updates the examples.

# Mandatory picture of a cute doggo

![](https://phaazon.net/media/uploads/pet_the_dog.gif)