### PR TITLE
Resetting cached GL state

### DIFF
--- a/luminance-gl/src/gl33.rs
+++ b/luminance-gl/src/gl33.rs
@@ -15,6 +15,7 @@ use self::state::GLState;
 pub use self::state::StateQueryError;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::ops::Deref;
 
 /// The OpenGL backend.
 pub struct GL33 {
@@ -26,5 +27,9 @@ impl GL33 {
     GLState::new().map(|state| GL33 {
       state: Rc::new(RefCell::new(state)),
     })
+  }
+
+  pub fn state(&self) -> &Rc<RefCell<GLState>> {
+    &self.state
   }
 }

--- a/luminance-gl/src/gl33.rs
+++ b/luminance-gl/src/gl33.rs
@@ -28,7 +28,7 @@ impl GL33 {
     })
   }
 
-  pub fn state(&self) -> &Rc<RefCell<GLState>> {
+  pub unsafe fn state(&self) -> &Rc<RefCell<GLState>> {
     &self.state
   }
 }

--- a/luminance-gl/src/gl33.rs
+++ b/luminance-gl/src/gl33.rs
@@ -15,7 +15,6 @@ use self::state::GLState;
 pub use self::state::StateQueryError;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::ops::Deref;
 
 /// The OpenGL backend.
 pub struct GL33 {

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -184,34 +184,42 @@ impl GLState {
     }
   }
 
+  /// Reset the cached vertex array
   pub fn reset_cached_vertex_array(&mut self) {
     self.bound_vertex_array = 0;
   }
 
+  /// Reset the cached array buffer
   pub fn reset_cached_array_buffer(&mut self) {
     self.bound_array_buffer = 0;
   }
 
+  /// Reset the cached shader program
   pub fn reset_cached_shader_program(&mut self) {
     self.current_program = 0;
   }
 
+  /// Reset the cached framebuffer
   pub fn reset_cached_framebuffer(&mut self) {
     self.bound_draw_framebuffer = 0;
   }
 
+  /// Reset the cached element array buffer
   pub fn reset_cached_element_array_buffer(&mut self) {
     self.bound_element_array_buffer = 0;
   }
 
+  /// Reset the cached texture unit
   pub fn reset_cached_texture_unit(&mut self) {
     self.current_texture_unit = 0;
   }
 
+  /// Reset the cached texture bindings
   pub fn reset_bound_textures(&mut self) {
     self.bound_textures.iter_mut().for_each(|t| *t = (gl::TEXTURE_2D, 0));
   }
 
+  /// Reset the cached uniform buffer bindings
   pub fn reset_bound_uniform_buffers(&mut self) {
     self.bound_uniform_buffers.iter_mut().for_each(|b| *b = 0);
   }

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -35,14 +35,20 @@ impl BindingStack {
   }
 }
 
-struct CachedValue<T> where T: PartialEq {
-  value: Option<T>
+struct CachedValue<T>
+where
+  T: PartialEq,
+{
+  value: Option<T>,
 }
 
-impl<T> CachedValue<T> where T: PartialEq {
+impl<T> CachedValue<T>
+where
+  T: PartialEq,
+{
   fn new(initial: T) -> Self {
     CachedValue {
-      value: Some(initial)
+      value: Some(initial),
     }
   }
 
@@ -57,7 +63,7 @@ impl<T> CachedValue<T> where T: PartialEq {
   fn is_invalid(&self, new_val: &T) -> bool {
     match &self.value {
       Some(t) if t == new_val => false,
-      _ => true
+      _ => true,
     }
   }
 }
@@ -407,7 +413,10 @@ impl GLState {
     &mut self,
     depth_test_comparison: DepthComparison,
   ) {
-    if self.depth_test_comparison.is_invalid(&depth_test_comparison) {
+    if self
+      .depth_test_comparison
+      .is_invalid(&depth_test_comparison)
+    {
       gl::DepthFunc(depth_comparison_to_glenum(depth_test_comparison));
       self.depth_test_comparison.set(depth_test_comparison);
     }
@@ -568,7 +577,10 @@ impl GLState {
   }
 
   pub(crate) unsafe fn enable_srgb_framebuffer(&mut self, srgb_framebuffer_enabled: bool) {
-    if self.srgb_framebuffer_enabled.is_invalid(&srgb_framebuffer_enabled) {
+    if self
+      .srgb_framebuffer_enabled
+      .is_invalid(&srgb_framebuffer_enabled)
+    {
       if srgb_framebuffer_enabled {
         gl::Enable(gl::FRAMEBUFFER_SRGB);
       } else {

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -184,6 +184,34 @@ impl GLState {
     }
   }
 
+  pub fn reset_cached_vertex_array(&mut self) {
+    self.bound_vertex_array = 0;
+  }
+
+  pub fn reset_cached_array_buffer(&mut self) {
+    self.bound_array_buffer = 0;
+  }
+
+  pub fn reset_cached_shader_program(&mut self) {
+    self.current_program = 0;
+  }
+
+  pub fn reset_cached_framebuffer(&mut self) {
+    self.bound_draw_framebuffer = 0;
+  }
+
+  pub fn reset_cached_element_array_buffer(&mut self) {
+    self.bound_element_array_buffer = 0;
+  }
+
+  pub fn reset_cached_texture_unit(&mut self) {
+    self.current_texture_unit = 0;
+  }
+
+  pub fn reset_bound_textures(&mut self) {
+    self.bound_textures.iter_mut().for_each(|t| *t = (gl::TEXTURE_2D, 0));
+  }
+
   pub(crate) fn binding_stack_mut(&mut self) -> &mut BindingStack {
     &mut self.binding_stack
   }

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -55,9 +55,13 @@ where
     self.0 = Some(value);
   }
 
+  /// Check if the cached value is invalid regarding a value.
+  ///
+  /// A non-cached value (i.e. empty) is always invalid whatever compared value. If a value is
+  /// already cached, then it’s invalid if it’s not equal ([`PartialEq`]) to the input value.
   fn is_invalid(&self, new_val: &T) -> bool {
     match &self.0 {
-      Some(ref t) => t == new_val,
+      Some(ref t) => t != new_val,
       _ => true,
     }
   }

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -212,6 +212,10 @@ impl GLState {
     self.bound_textures.iter_mut().for_each(|t| *t = (gl::TEXTURE_2D, 0));
   }
 
+  pub fn reset_bound_uniform_buffers(&mut self) {
+    self.bound_uniform_buffers.iter_mut().for_each(|b| *b = 0);
+  }
+
   pub(crate) fn binding_stack_mut(&mut self) -> &mut BindingStack {
     &mut self.binding_stack
   }

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -251,7 +251,7 @@ impl GLState {
   }
 
   /// Reset the cached texture bindings
-  pub fn reset_bound_textures(&mut self) {
+  pub fn reset_cached_bound_textures(&mut self) {
     self
       .bound_textures
       .iter_mut()
@@ -259,8 +259,73 @@ impl GLState {
   }
 
   /// Reset the cached uniform buffer bindings
-  pub fn reset_bound_uniform_buffers(&mut self) {
+  pub fn reset_cached_bound_uniform_buffers(&mut self) {
     self.bound_uniform_buffers.iter_mut().for_each(|b| *b = 0);
+  }
+
+  /// Reset the cached viewport
+  pub fn reset_cached_viewport(&mut self) {
+    self.viewport.mark_dirty()
+  }
+
+  /// Reset the cached clear color
+  pub fn reset_cached_clear_color(&mut self) {
+    self.clear_color.mark_dirty()
+  }
+
+  /// Reset the cached blending state
+  pub fn reset_cached_blending_state(&mut self) {
+    self.blending_state.mark_dirty()
+  }
+
+  /// Reset the cached blending equation
+  pub fn reset_cached_blending_equation(&mut self) {
+    self.blending_equation.mark_dirty()
+  }
+
+  /// Reset the cached blending function
+  pub fn reset_cached_blending_func(&mut self) {
+    self.blending_func.mark_dirty()
+  }
+
+  /// Reset the cached depth test
+  pub fn reset_cached_depth_test(&mut self) {
+    self.depth_test.mark_dirty()
+  }
+
+  /// Reset the cached depth test comparison
+  pub fn reset_cached_depth_test_comparison(&mut self) {
+    self.depth_test_comparison.mark_dirty()
+  }
+
+  /// Reset the cached face culling state
+  pub fn reset_cached_face_culling_state(&mut self) {
+    self.face_culling_state.mark_dirty()
+  }
+
+  /// Reset the cached face culling order
+  pub fn reset_cached_face_culling_order(&mut self) {
+    self.face_culling_order.mark_dirty()
+  }
+
+  /// Reset cached face culling mode
+  pub fn reset_cached_face_culling_mode(&mut self) {
+    self.face_culling_mode.mark_dirty()
+  }
+
+  /// Reset cached vertex restart
+  pub fn reset_cached_vertex_restart(&mut self) {
+    self.vertex_restart.mark_dirty()
+  }
+
+  /// Reset cached patch vertex number
+  pub fn reset_cached_patch_vertex_nb(&mut self) {
+    self.patch_vertex_nb.mark_dirty()
+  }
+
+  /// Reset cached SRGB framebuffer flag
+  pub fn reset_srgb_framebuffer_enabled(&mut self) {
+    self.srgb_framebuffer_enabled.mark_dirty()
   }
 
   pub(crate) fn binding_stack_mut(&mut self) -> &mut BindingStack {

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -212,110 +212,110 @@ impl GLState {
     }
   }
 
-  /// Reset the cached vertex array
-  pub fn reset_cached_vertex_array(&mut self) {
+  /// Invalidate the cached vertex array
+  pub fn invalidate_vertex_array(&mut self) {
     self.bound_vertex_array = 0;
   }
 
-  /// Reset the cached array buffer
-  pub fn reset_cached_array_buffer(&mut self) {
+  /// Invalidate the array buffer
+  pub fn invalidate_array_buffer(&mut self) {
     self.bound_array_buffer = 0;
   }
 
-  /// Reset the cached shader program
-  pub fn reset_cached_shader_program(&mut self) {
+  /// Invalidate the shader program
+  pub fn invalidate_shader_program(&mut self) {
     self.current_program = 0;
   }
 
-  /// Reset the cached framebuffer
-  pub fn reset_cached_framebuffer(&mut self) {
+  /// Invalidate the framebuffer
+  pub fn invalidate_framebuffer(&mut self) {
     self.bound_draw_framebuffer = 0;
   }
 
-  /// Reset the cached element array buffer
-  pub fn reset_cached_element_array_buffer(&mut self) {
+  /// Invalidate the element array buffer
+  pub fn invalidate_element_array_buffer(&mut self) {
     self.bound_element_array_buffer = 0;
   }
 
-  /// Reset the cached texture unit
-  pub fn reset_cached_texture_unit(&mut self) {
+  /// Invalidate the texture unit
+  pub fn invalidate_texture_unit(&mut self) {
     self.current_texture_unit = 0;
   }
 
-  /// Reset the cached texture bindings
-  pub fn reset_cached_bound_textures(&mut self) {
+  /// Invalidate the texture bindings
+  pub fn invalidate_bound_textures(&mut self) {
     self
       .bound_textures
       .iter_mut()
       .for_each(|t| *t = (gl::TEXTURE_2D, 0));
   }
 
-  /// Reset the cached uniform buffer bindings
-  pub fn reset_cached_bound_uniform_buffers(&mut self) {
+  /// Invalidate the uniform buffer bindings
+  pub fn invalidate_bound_uniform_buffers(&mut self) {
     self.bound_uniform_buffers.iter_mut().for_each(|b| *b = 0);
   }
 
-  /// Reset the cached viewport
-  pub fn reset_cached_viewport(&mut self) {
+  /// Invalidate the viewport
+  pub fn invalidate_viewport(&mut self) {
     self.viewport.invalidate()
   }
 
-  /// Reset the cached clear color
-  pub fn reset_cached_clear_color(&mut self) {
+  /// Invalidate the clear color
+  pub fn invalidate_clear_color(&mut self) {
     self.clear_color.invalidate()
   }
 
-  /// Reset the cached blending state
-  pub fn reset_cached_blending_state(&mut self) {
+  /// Invalidate the blending state
+  pub fn invalidate_blending_state(&mut self) {
     self.blending_state.invalidate()
   }
 
-  /// Reset the cached blending equation
-  pub fn reset_cached_blending_equation(&mut self) {
+  /// Invalidate the blending equation
+  pub fn invalidate_blending_equation(&mut self) {
     self.blending_equation.invalidate()
   }
 
-  /// Reset the cached blending function
-  pub fn reset_cached_blending_func(&mut self) {
+  /// Invalidate the blending function
+  pub fn invalidate_blending_func(&mut self) {
     self.blending_func.invalidate()
   }
 
-  /// Reset the cached depth test
-  pub fn reset_cached_depth_test(&mut self) {
+  /// Invalidate the depth test
+  pub fn invalidate_depth_test(&mut self) {
     self.depth_test.invalidate()
   }
 
-  /// Reset the cached depth test comparison
-  pub fn reset_cached_depth_test_comparison(&mut self) {
+  /// Invalidate the depth test comparison
+  pub fn invalidate_depth_test_comparison(&mut self) {
     self.depth_test_comparison.invalidate()
   }
 
-  /// Reset the cached face culling state
-  pub fn reset_cached_face_culling_state(&mut self) {
+  /// Invalidate the face culling state
+  pub fn invalidate_face_culling_state(&mut self) {
     self.face_culling_state.invalidate()
   }
 
-  /// Reset the cached face culling order
-  pub fn reset_cached_face_culling_order(&mut self) {
+  /// Invalidate the face culling order
+  pub fn invalidate_face_culling_order(&mut self) {
     self.face_culling_order.invalidate()
   }
 
-  /// Reset cached face culling mode
-  pub fn reset_cached_face_culling_mode(&mut self) {
+  /// Invalidate the face culling mode
+  pub fn invalidate_face_culling_mode(&mut self) {
     self.face_culling_mode.invalidate()
   }
 
-  /// Reset cached vertex restart
-  pub fn reset_cached_vertex_restart(&mut self) {
+  /// Invalidate the vertex restart
+  pub fn invalidate_vertex_restart(&mut self) {
     self.vertex_restart.invalidate()
   }
 
-  /// Reset cached patch vertex number
-  pub fn reset_cached_patch_vertex_nb(&mut self) {
+  /// Invalidate the patch vertex number
+  pub fn invalidate_patch_vertex_nb(&mut self) {
     self.patch_vertex_nb.invalidate()
   }
 
-  /// Reset cached SRGB framebuffer flag
+  /// Invalidate the SRGB framebuffer flag
   pub fn reset_srgb_framebuffer_enabled(&mut self) {
     self.srgb_framebuffer_enabled.invalidate()
   }

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -16,6 +16,7 @@ use luminance::face_culling::{FaceCullingMode, FaceCullingOrder};
 // Note: disable on no_std.
 thread_local!(static TLS_ACQUIRE_GFX_STATE: RefCell<Option<()>> = RefCell::new(Some(())));
 
+#[derive(Debug)]
 pub(crate) struct BindingStack {
   pub(crate) next_texture_unit: u32,
   pub(crate) free_texture_units: Vec<u32>,
@@ -49,6 +50,7 @@ impl BindingStack {
 /// Note: do not confuse [`Cached`] with [`Bind`]. The latter is for internal use only and
 /// is used to either use the regular cache mechanism or override it to force a value to be
 /// written. It cannot be used to invalidate a setting for later use.
+#[derive(Debug)]
 struct Cached<T>(Option<T>)
 where
   T: PartialEq;
@@ -91,6 +93,7 @@ where
 /// as a forward-gate to all the exposed features from the low-level API but
 /// adds a small cache layer over it to prevent from issuing the same API call (with
 /// the same parameters).
+#[derive(Debug)]
 pub struct GLState {
   _a: PhantomData<*const ()>, // !Send and !Sync
 


### PR DESCRIPTION
Implements #333.
Exposes GLState and adds several `reset` functions to it that allow invalidating the values cached in the state. Purpose of this is to enable using luminance together with other libraries that use OpenGL.