### PR TITLE
Make the backend interface of buffers Copy friendly.

### DIFF
--- a/luminance-gl/src/gl33/buffer.rs
+++ b/luminance-gl/src/gl33/buffer.rs
@@ -24,7 +24,10 @@ pub struct Buffer {
   state: Rc<RefCell<GLState>>,
 }
 
-unsafe impl<T> BufferBackend<T> for GL33 {
+unsafe impl<T> BufferBackend<T> for GL33
+where
+  T: Copy,
+{
   type BufferRepr = Buffer;
 
   unsafe fn new_buffer(&mut self, len: usize) -> Result<Self::BufferRepr, BufferError>
@@ -69,7 +72,6 @@ unsafe impl<T> BufferBackend<T> for GL33 {
   unsafe fn from_slice<S>(&mut self, slice: S) -> Result<Self::BufferRepr, BufferError>
   where
     S: AsRef<[T]>,
-    T: Copy,
   {
     let mut buffer: GLuint = 0;
     let slice = slice.as_ref();
@@ -98,17 +100,14 @@ unsafe impl<T> BufferBackend<T> for GL33 {
 
   unsafe fn repeat(&mut self, len: usize, value: T) -> Result<Self::BufferRepr, BufferError>
   where
-    T: Copy + Default,
+    T: Default,
   {
     let mut buf = <Self as BufferBackend<T>>::new_buffer(self, len)?;
     Self::clear(&mut buf, value)?;
     Ok(buf)
   }
 
-  unsafe fn at(buffer: &Self::BufferRepr, i: usize) -> Option<T>
-  where
-    T: Copy,
-  {
+  unsafe fn at(buffer: &Self::BufferRepr, i: usize) -> Option<T> {
     if i >= buffer.len {
       None
     } else {
@@ -124,10 +123,7 @@ unsafe impl<T> BufferBackend<T> for GL33 {
     }
   }
 
-  unsafe fn whole(buffer: &Self::BufferRepr) -> Vec<T>
-  where
-    T: Copy,
-  {
+  unsafe fn whole(buffer: &Self::BufferRepr) -> Vec<T> {
     buffer
       .state
       .borrow_mut()
@@ -139,10 +135,7 @@ unsafe impl<T> BufferBackend<T> for GL33 {
     values
   }
 
-  unsafe fn set(buffer: &mut Self::BufferRepr, i: usize, x: T) -> Result<(), BufferError>
-  where
-    T: Copy,
-  {
+  unsafe fn set(buffer: &mut Self::BufferRepr, i: usize, x: T) -> Result<(), BufferError> {
     if i >= buffer.len {
       Err(BufferError::Overflow {
         index: i,
@@ -195,10 +188,7 @@ unsafe impl<T> BufferBackend<T> for GL33 {
     Ok(())
   }
 
-  unsafe fn clear(buffer: &mut Self::BufferRepr, x: T) -> Result<(), BufferError>
-  where
-    T: Copy,
-  {
+  unsafe fn clear(buffer: &mut Self::BufferRepr, x: T) -> Result<(), BufferError> {
     Self::write_whole(buffer, &vec![x; buffer.len])
   }
 }
@@ -213,7 +203,10 @@ pub struct BufferSliceMut<T> {
   ptr: *mut T,
 }
 
-unsafe impl<T> BufferSliceBackend<T> for GL33 {
+unsafe impl<T> BufferSliceBackend<T> for GL33
+where
+  T: Copy,
+{
   type SliceRepr = BufferSlice<T>;
 
   type SliceMutRepr = BufferSliceMut<T>;

--- a/luminance-gl/src/gl33/pipeline.rs
+++ b/luminance-gl/src/gl33/pipeline.rs
@@ -135,7 +135,10 @@ where
   }
 }
 
-unsafe impl<T> PipelineBuffer<T> for GL33 {
+unsafe impl<T> PipelineBuffer<T> for GL33
+where
+  T: Copy,
+{
   type BoundBufferRepr = BoundBuffer;
 
   unsafe fn bind_buffer(

--- a/luminance-gl/src/gl33/tess.rs
+++ b/luminance-gl/src/gl33/tess.rs
@@ -421,7 +421,10 @@ unsafe impl TessBackend for GL33 {
   }
 }
 
-unsafe impl<T> TessSlice<T> for GL33 {
+unsafe impl<T> TessSlice<T> for GL33
+where
+  T: Copy,
+{
   type SliceRepr = BufferSlice<T>;
 
   type SliceMutRepr = BufferSliceMut<T>;

--- a/luminance/src/backend/buffer.rs
+++ b/luminance/src/backend/buffer.rs
@@ -4,7 +4,10 @@
 
 use crate::buffer::BufferError;
 
-pub unsafe trait Buffer<T> {
+pub unsafe trait Buffer<T>
+where
+  T: Copy,
+{
   /// The inner representation of the buffer for this backend.
   type BufferRepr;
 
@@ -20,33 +23,27 @@ pub unsafe trait Buffer<T> {
   /// Create a new buffer from a slice.
   unsafe fn from_slice<S>(&mut self, slice: S) -> Result<Self::BufferRepr, BufferError>
   where
-    S: AsRef<[T]>,
-    T: Copy;
+    S: AsRef<[T]>;
 
   unsafe fn repeat(&mut self, len: usize, value: T) -> Result<Self::BufferRepr, BufferError>
   where
-    T: Copy + Default;
+    T: Default;
 
-  unsafe fn at(buffer: &Self::BufferRepr, i: usize) -> Option<T>
-  where
-    T: Copy;
+  unsafe fn at(buffer: &Self::BufferRepr, i: usize) -> Option<T>;
 
-  unsafe fn whole(buffer: &Self::BufferRepr) -> Vec<T>
-  where
-    T: Copy;
+  unsafe fn whole(buffer: &Self::BufferRepr) -> Vec<T>;
 
-  unsafe fn set(buffer: &mut Self::BufferRepr, i: usize, x: T) -> Result<(), BufferError>
-  where
-    T: Copy;
+  unsafe fn set(buffer: &mut Self::BufferRepr, i: usize, x: T) -> Result<(), BufferError>;
 
   unsafe fn write_whole(buffer: &mut Self::BufferRepr, values: &[T]) -> Result<(), BufferError>;
 
-  unsafe fn clear(buffer: &mut Self::BufferRepr, x: T) -> Result<(), BufferError>
-  where
-    T: Copy;
+  unsafe fn clear(buffer: &mut Self::BufferRepr, x: T) -> Result<(), BufferError>;
 }
 
-pub unsafe trait BufferSlice<T>: Buffer<T> {
+pub unsafe trait BufferSlice<T>: Buffer<T>
+where
+  T: Copy,
+{
   type SliceRepr;
 
   type SliceMutRepr;

--- a/luminance/src/backend/pipeline.rs
+++ b/luminance/src/backend/pipeline.rs
@@ -27,7 +27,10 @@ where
   );
 }
 
-pub unsafe trait PipelineBuffer<T>: PipelineBase + Buffer<T> {
+pub unsafe trait PipelineBuffer<T>: PipelineBase + Buffer<T>
+where
+  T: Copy,
+{
   type BoundBufferRepr;
 
   unsafe fn bind_buffer(

--- a/luminance/src/buffer.rs
+++ b/luminance/src/buffer.rs
@@ -62,6 +62,7 @@ use std::marker::PhantomData;
 pub struct Buffer<B, T>
 where
   B: ?Sized + BufferBackend<T>,
+  T: Copy,
 {
   pub(crate) repr: B::BufferRepr,
   _t: PhantomData<T>,
@@ -70,6 +71,7 @@ where
 impl<B, T> Drop for Buffer<B, T>
 where
   B: ?Sized + BufferBackend<T>,
+  T: Copy,
 {
   fn drop(&mut self) {
     unsafe { <B as BufferBackend<T>>::destroy_buffer(&mut self.repr) };
@@ -79,6 +81,7 @@ where
 impl<B, T> Buffer<B, T>
 where
   B: ?Sized + BufferBackend<T>,
+  T: Copy,
 {
   /// Create a new buffer with a given length
   ///
@@ -130,7 +133,6 @@ where
   where
     C: GraphicsContext<Backend = B>,
     X: AsRef<[T]>,
-    T: Copy,
   {
     let repr = unsafe { ctx.backend().from_slice(slice)? };
 
@@ -157,7 +159,7 @@ where
   pub fn repeat<C>(ctx: &mut C, len: usize, value: T) -> Result<Self, BufferError>
   where
     C: GraphicsContext<Backend = B>,
-    T: Copy + Default,
+    T: Default,
   {
     let repr = unsafe { ctx.backend().repeat(len, value)? };
 
@@ -168,18 +170,12 @@ where
   }
 
   /// Get the item at the given index.
-  pub fn at(&self, i: usize) -> Option<T>
-  where
-    T: Copy,
-  {
+  pub fn at(&self, i: usize) -> Option<T> {
     unsafe { B::at(&self.repr, i) }
   }
 
   /// Get the whole content of the buffer and store it inside a [`Vec`].
-  pub fn whole(&self) -> Vec<T>
-  where
-    T: Copy,
-  {
+  pub fn whole(&self) -> Vec<T> {
     unsafe { B::whole(&self.repr) }
   }
 
@@ -190,10 +186,7 @@ where
   /// That function returns [`BufferError::Overflow`] if `i` is bigger than the length of the
   /// buffer. Other errors are possible; please consider reading the documentation of
   /// [`BufferError`] for further information.
-  pub fn set(&mut self, i: usize, x: T) -> Result<(), BufferError>
-  where
-    T: Copy,
-  {
+  pub fn set(&mut self, i: usize, x: T) -> Result<(), BufferError> {
     unsafe { B::set(&mut self.repr, i, x) }
   }
 
@@ -210,10 +203,7 @@ where
   }
 
   /// Clear the content of the buffer by copying the same value everywhere.
-  pub fn clear(&mut self, x: T) -> Result<(), BufferError>
-  where
-    T: Copy,
-  {
+  pub fn clear(&mut self, x: T) -> Result<(), BufferError> {
     unsafe { B::clear(&mut self.repr, x) }
   }
 
@@ -239,6 +229,7 @@ where
 impl<B, T> Buffer<B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   /// Create a new [`BufferSlice`] from a buffer, allowing to get `&[T]` out of it.
   ///
@@ -352,6 +343,7 @@ impl fmt::Display for BufferError {
 pub struct BufferSlice<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   slice: B::SliceRepr,
   _a: PhantomData<&'a mut ()>,
@@ -360,6 +352,7 @@ where
 impl<'a, B, T> Drop for BufferSlice<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   fn drop(&mut self) {
     {
@@ -371,6 +364,7 @@ where
 impl<'a, B, T> BufferSlice<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   /// Obtain a `&[T]`.
   ///
@@ -388,6 +382,7 @@ where
 pub struct BufferSliceMut<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   slice: B::SliceMutRepr,
   _a: PhantomData<&'a mut ()>,
@@ -396,6 +391,7 @@ where
 impl<'a, B, T> Drop for BufferSliceMut<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   fn drop(&mut self) {
     unsafe { B::destroy_buffer_slice_mut(&mut self.slice) };
@@ -405,6 +401,7 @@ where
 impl<'a, B, T> BufferSliceMut<'a, B, T>
 where
   B: ?Sized + BufferSliceBackend<T>,
+  T: Copy,
 {
   /// Obtain a `&mut [T]`.
   pub fn as_slice_mut(&mut self) -> Result<&mut [T], BufferError> {

--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -406,6 +406,7 @@ where
   ) -> Result<BoundBuffer<'a, B, T>, PipelineError>
   where
     B: PipelineBuffer<T>,
+    T: Copy,
   {
     unsafe {
       B::bind_buffer(&self.repr, &buffer.repr).map(|repr| BoundBuffer {
@@ -553,6 +554,7 @@ impl<T> BufferBinding<T> {
 pub struct BoundBuffer<'a, B, T>
 where
   B: PipelineBuffer<T>,
+  T: Copy,
 {
   pub(crate) repr: B::BoundBufferRepr,
   _phantom: PhantomData<&'a T>,
@@ -561,6 +563,7 @@ where
 impl<'a, B, T> BoundBuffer<'a, B, T>
 where
   B: PipelineBuffer<T>,
+  T: Copy,
 {
   /// Obtain a [`BufferBinding`] object that can be used to refer to this bound buffer in shader
   /// stages.


### PR DESCRIPTION
This is currently needed for #232, but it will be useful for pretty much
any backend too.