### PR TITLE
implement std::error::Error for errors in all crates

### DIFF
--- a/luminance-derive/src/attrib.rs
+++ b/luminance-derive/src/attrib.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::fmt;
 use syn::parse::Parse;
 use syn::{Attribute, Ident, Lit, Meta, NestedMeta};
@@ -34,6 +35,8 @@ impl fmt::Display for AttrError {
     }
   }
 }
+
+impl error::Error for AttrError {}
 
 /// Get and parse an attribute on a field or a variant that must appear only once with the following
 /// syntax:

--- a/luminance-derive/src/semantics.rs
+++ b/luminance-derive/src/semantics.rs
@@ -31,18 +31,12 @@ impl fmt::Display for SemanticsImplError {
 }
 
 impl error::Error for SemanticsImplError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    SemanticsImplError::AttributeErrors(ref ve) => {
-		if ve.len() > 0 {
-		    return Some(&ve[0])
-		} else {
-		    return None;
-		}
-	    },
-	    _ => None
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      SemanticsImplError::AttributeErrors(ref ve) => ve.first().map(|x| x as &dyn error::Error),
+      _ => None,
     }
+  }
 }
 
 /// Get vertex semantics attributes.

--- a/luminance-derive/src/semantics.rs
+++ b/luminance-derive/src/semantics.rs
@@ -1,6 +1,7 @@
 use crate::attrib::{get_field_attr_once, AttrError};
 use proc_macro::TokenStream;
 use quote::quote;
+use std::error;
 use std::fmt;
 use syn::{Attribute, DataEnum, Ident, Type};
 
@@ -27,6 +28,21 @@ impl fmt::Display for SemanticsImplError {
       SemanticsImplError::NoField => f.write_str("semantics cannot be empty sets"),
     }
   }
+}
+
+impl error::Error for SemanticsImplError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    SemanticsImplError::AttributeErrors(ref ve) => {
+		if ve.len() > 0 {
+		    return Some(&ve[0])
+		} else {
+		    return None;
+		}
+	    },
+	    _ => None
+	}
+    }
 }
 
 /// Get vertex semantics attributes.

--- a/luminance-derive/src/uniform_interface.rs
+++ b/luminance-derive/src/uniform_interface.rs
@@ -34,13 +34,13 @@ impl fmt::Display for DeriveUniformInterfaceError {
 }
 
 impl error::Error for DeriveUniformInterfaceError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    DeriveUniformInterfaceError::UnboundError(e) => Some(e),
-	    DeriveUniformInterfaceError::NameError(e) => Some(e),
-	    _ => None
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      DeriveUniformInterfaceError::UnboundError(e) => Some(e),
+      DeriveUniformInterfaceError::NameError(e) => Some(e),
+      _ => None,
     }
+  }
 }
 
 pub(crate) fn generate_uniform_interface_impl(

--- a/luminance-derive/src/uniform_interface.rs
+++ b/luminance-derive/src/uniform_interface.rs
@@ -1,6 +1,7 @@
 use crate::attrib::{get_field_attr_once, get_field_flag_once, AttrError};
 use proc_macro::TokenStream;
 use quote::quote;
+use std::error;
 use std::fmt;
 use syn::{DataStruct, Fields, Ident, Path, PathArguments, Type, TypePath};
 
@@ -30,6 +31,16 @@ impl fmt::Display for DeriveUniformInterfaceError {
       ),
     }
   }
+}
+
+impl error::Error for DeriveUniformInterfaceError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    DeriveUniformInterfaceError::UnboundError(e) => Some(e),
+	    DeriveUniformInterfaceError::NameError(e) => Some(e),
+	    _ => None
+	}
+    }
 }
 
 pub(crate) fn generate_uniform_interface_impl(

--- a/luminance-derive/src/vertex.rs
+++ b/luminance-derive/src/vertex.rs
@@ -26,13 +26,13 @@ impl fmt::Display for StructImplError {
 }
 
 impl error::Error for StructImplError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    StructImplError::SemanticsError(e) => Some(e),
-	    StructImplError::FieldError(e) => Some(e),
-	    _ => None
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      StructImplError::SemanticsError(e) => Some(e),
+      StructImplError::FieldError(e) => Some(e),
+      _ => None,
     }
+  }
 }
 
 /// Generate the Vertex impl for a struct.

--- a/luminance-derive/src/vertex.rs
+++ b/luminance-derive/src/vertex.rs
@@ -1,6 +1,7 @@
 use crate::attrib::{get_field_attr_once, AttrError};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
+use std::error;
 use std::fmt;
 use syn::{Attribute, DataStruct, Field, Fields, Ident, LitBool, Type};
 
@@ -22,6 +23,16 @@ impl fmt::Display for StructImplError {
       StructImplError::UnsupportedUnit => f.write_str("unsupported unit struct"),
     }
   }
+}
+
+impl error::Error for StructImplError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    StructImplError::SemanticsError(e) => Some(e),
+	    StructImplError::FieldError(e) => Some(e),
+	    _ => None
+	}
+    }
 }
 
 /// Generate the Vertex impl for a struct.

--- a/luminance-gl/src/gl33/state.rs
+++ b/luminance-gl/src/gl33/state.rs
@@ -2,6 +2,7 @@
 
 use gl::types::*;
 use std::cell::RefCell;
+use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -540,6 +541,8 @@ impl fmt::Display for StateQueryError {
     }
   }
 }
+
+impl error::Error for StateQueryError {}
 
 unsafe fn get_ctx_viewport() -> Result<[GLint; 4], StateQueryError> {
   let mut data = [0; 4];

--- a/luminance-glfw/src/lib.rs
+++ b/luminance-glfw/src/lib.rs
@@ -12,6 +12,7 @@ use luminance::texture::Dim2;
 pub use luminance_gl::gl33::StateQueryError;
 use luminance_gl::GL33;
 pub use luminance_windowing::{CursorMode, WindowDim, WindowOpt};
+use std::error;
 use std::fmt;
 use std::os::raw::c_void;
 use std::sync::mpsc::Receiver;
@@ -51,6 +52,16 @@ impl fmt::Display for GlfwSurfaceError {
       }
     }
   }
+}
+
+impl error::Error for GlfwSurfaceError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    GlfwSurfaceError::InitError(e) => Some(e),
+	    GlfwSurfaceError::GraphicsStateError(e) => Some(e),
+	    _ => None
+	}
+    }
 }
 
 /// GLFW surface.

--- a/luminance-glfw/src/lib.rs
+++ b/luminance-glfw/src/lib.rs
@@ -55,13 +55,13 @@ impl fmt::Display for GlfwSurfaceError {
 }
 
 impl error::Error for GlfwSurfaceError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    GlfwSurfaceError::InitError(e) => Some(e),
-	    GlfwSurfaceError::GraphicsStateError(e) => Some(e),
-	    _ => None
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      GlfwSurfaceError::InitError(e) => Some(e),
+      GlfwSurfaceError::GraphicsStateError(e) => Some(e),
+      _ => None,
     }
+  }
 }
 
 /// GLFW surface.

--- a/luminance-glutin/src/lib.rs
+++ b/luminance-glutin/src/lib.rs
@@ -48,13 +48,13 @@ impl fmt::Display for GlutinError {
 }
 
 impl error::Error for GlutinError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    GlutinError::CreationError(e) => Some(e),
-	    GlutinError::ContextError(e) => Some(e),
-	    GlutinError::GraphicsStateError(e) =>Some(e)
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      GlutinError::CreationError(e) => Some(e),
+      GlutinError::ContextError(e) => Some(e),
+      GlutinError::GraphicsStateError(e) => Some(e),
     }
+  }
 }
 
 impl From<CreationError> for GlutinError {
@@ -74,7 +74,6 @@ impl From<StateQueryError> for GlutinError {
     GlutinError::GraphicsStateError(e)
   }
 }
-
 
 /// The Glutin surface.
 ///

--- a/luminance-glutin/src/lib.rs
+++ b/luminance-glutin/src/lib.rs
@@ -19,6 +19,7 @@ pub use luminance_gl::gl33::StateQueryError;
 use luminance_gl::GL33;
 pub use luminance_windowing::{CursorMode, WindowDim, WindowOpt};
 
+use std::error;
 use std::fmt;
 use std::os::raw::c_void;
 
@@ -46,6 +47,16 @@ impl fmt::Display for GlutinError {
   }
 }
 
+impl error::Error for GlutinError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    GlutinError::CreationError(e) => Some(e),
+	    GlutinError::ContextError(e) => Some(e),
+	    GlutinError::GraphicsStateError(e) =>Some(e)
+	}
+    }
+}
+
 impl From<CreationError> for GlutinError {
   fn from(e: CreationError) -> Self {
     GlutinError::CreationError(e)
@@ -57,6 +68,13 @@ impl From<ContextError> for GlutinError {
     GlutinError::ContextError(e)
   }
 }
+
+impl From<StateQueryError> for GlutinError {
+  fn from(e: StateQueryError) -> Self {
+    GlutinError::GraphicsStateError(e)
+  }
+}
+
 
 /// The Glutin surface.
 ///

--- a/luminance/src/buffer.rs
+++ b/luminance/src/buffer.rs
@@ -46,6 +46,7 @@
 use crate::backend::buffer::{Buffer as BufferBackend, BufferSlice as BufferSliceBackend};
 use crate::context::GraphicsContext;
 
+use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -341,6 +342,8 @@ impl fmt::Display for BufferError {
     }
   }
 }
+
+impl error::Error for BufferError {}
 
 /// A buffer slice, allowing to get `&[T]`.
 #[derive(Debug)]

--- a/luminance/src/framebuffer.rs
+++ b/luminance/src/framebuffer.rs
@@ -60,6 +60,7 @@
 //! [backend::depth_slot]: crate::backend::depth_slot
 //! [`PipelineGate`]: crate::pipeline::PipelineGate
 
+use std::error;
 use std::fmt;
 
 use crate::backend::color_slot::ColorSlot;
@@ -234,6 +235,15 @@ impl fmt::Display for FramebufferError {
   }
 }
 
+impl std::error::Error for FramebufferError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      FramebufferError::TextureError(e) => Some(e),
+      FramebufferError::Incomplete(e) => Some(e),
+    }
+  }
+}
+
 impl From<TextureError> for FramebufferError {
   fn from(e: TextureError) -> Self {
     FramebufferError::TextureError(e)
@@ -281,3 +291,5 @@ impl fmt::Display for IncompleteReason {
     }
   }
 }
+
+impl error::Error for IncompleteReason {}

--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -236,6 +236,7 @@ use crate::shading_gate::ShadingGate;
 use crate::texture::Dimensionable;
 use crate::texture::Texture;
 
+use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -249,6 +250,8 @@ impl fmt::Display for PipelineError {
     Ok(())
   }
 }
+
+impl error::Error for PipelineError {}
 
 /// The viewport being part of the [`PipelineState`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/luminance/src/shader.rs
+++ b/luminance/src/shader.rs
@@ -277,12 +277,12 @@ impl fmt::Display for ProgramWarning {
 }
 
 impl error::Error for ProgramWarning {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-	match self {
-	    ProgramWarning::Uniform(e) => Some(e),
-	    ProgramWarning::VertexAttrib(e) => Some(e)
-	}
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      ProgramWarning::Uniform(e) => Some(e),
+      ProgramWarning::VertexAttrib(e) => Some(e),
     }
+  }
 }
 
 impl From<ProgramWarning> for ProgramError {

--- a/luminance/src/shader.rs
+++ b/luminance/src/shader.rs
@@ -141,6 +141,7 @@
 //! [`BoundBuffer`]: crate::pipeline::BoundBuffer
 //! [`BufferBinding`]: crate::pipeline::BufferBinding
 
+use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -194,6 +195,8 @@ impl fmt::Display for StageError {
   }
 }
 
+impl error::Error for StageError {}
+
 impl From<StageError> for ProgramError {
   fn from(e: StageError) -> Self {
     ProgramError::StageError(e)
@@ -245,6 +248,15 @@ impl fmt::Display for ProgramError {
   }
 }
 
+impl error::Error for ProgramError {
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      ProgramError::StageError(e) => Some(e),
+      _ => None,
+    }
+  }
+}
+
 /// Program warnings, not necessarily considered blocking errors.
 #[derive(Debug)]
 pub enum ProgramWarning {
@@ -262,6 +274,15 @@ impl fmt::Display for ProgramWarning {
       ProgramWarning::VertexAttrib(ref e) => write!(f, "vertex attribute warning: {}", e),
     }
   }
+}
+
+impl error::Error for ProgramWarning {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+	match self {
+	    ProgramWarning::Uniform(e) => Some(e),
+	    ProgramWarning::VertexAttrib(e) => Some(e)
+	}
+    }
 }
 
 impl From<ProgramWarning> for ProgramError {
@@ -320,6 +341,8 @@ impl From<UniformWarning> for ProgramWarning {
   }
 }
 
+impl error::Error for UniformWarning {}
+
 /// Warnings related to vertex attributes issues.
 #[derive(Debug)]
 pub enum VertexAttribWarning {
@@ -340,6 +363,8 @@ impl From<VertexAttribWarning> for ProgramWarning {
     ProgramWarning::VertexAttrib(e)
   }
 }
+
+impl error::Error for VertexAttribWarning {}
 
 /// A GPU shader program environment variable.
 ///

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -60,6 +60,7 @@
 //!
 //! [`TessGate`]: crate::tess_gate::TessGate
 
+use std::error;
 use std::fmt;
 use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
@@ -180,6 +181,15 @@ impl fmt::Display for TessMapError {
   }
 }
 
+impl error::Error for TessMapError {
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      TessMapError::BufferMapError(e) => Some(e),
+      _ => None,
+    }
+  }
+}
+
 /// Possible errors that might occur when dealing with [`Tess`].
 #[derive(Debug)]
 pub enum TessError {
@@ -193,9 +203,29 @@ pub enum TessError {
   InternalBufferError(BufferError),
 }
 
+impl fmt::Display for TessError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match self {
+      TessError::AttributelessError(s) => write!(f, "Attributeless error: {}", s),
+      TessError::LengthIncoherency(s) => write!(f, "Incoherent size for internal buffers: {}", s),
+      TessError::Overflow(a, b) => write!(f, "Tess overflow error: {}, {}", a, b),
+      TessError::InternalBufferError(e) => write!(f, "internal buffer error: {}", e),
+    }
+  }
+}
+
 impl From<BufferError> for TessError {
   fn from(e: BufferError) -> Self {
     TessError::InternalBufferError(e)
+  }
+}
+
+impl error::Error for TessError {
+  fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    match self {
+      TessError::InternalBufferError(e) => Some(e),
+      _ => None,
+    }
   }
 }
 
@@ -612,6 +642,19 @@ pub enum TessViewError {
     nb: usize,
   },
 }
+
+impl fmt::Display for TessViewError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match self {
+	    TessViewError::IncorrectViewWindow{ capacity, start, nb } => {
+		write!(f, "TessView incorrect window error: requested slice size {} starting at {}, but capacity is only {}", 
+		       nb, start, capacity)
+	    }
+	}
+  }
+}
+
+impl error::Error for TessViewError {}
 
 /// A _view_ into a GPU tessellation.
 #[derive(Clone)]

--- a/luminance/src/texture.rs
+++ b/luminance/src/texture.rs
@@ -29,6 +29,7 @@
 //!
 //! # Creating a texture
 
+use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -478,6 +479,8 @@ impl fmt::Display for TextureError {
     }
   }
 }
+
+impl error::Error for TextureError {}
 
 /// GPU textures.
 pub struct Texture<B, D, P>


### PR DESCRIPTION
A couple of notes:

* I didn't try to necessarily improve the error text at all. In the few places where I had to actually add text, it's relatively barebones, but I can make improvements there if you want.
* `luminance-derive::SemanticsImplError::AttributeErrors` is a vector of errors, so I use the first one (arbitrarily) as a source.
* I implemented `error::Error` for `ProgramWarning`, despite it not quite being an error. 
