### PR TITLE
Support separate rgb/alpha for blending equations and factors. #296

### DIFF
--- a/luminance-gl/src/gl33/pipeline.rs
+++ b/luminance-gl/src/gl33/pipeline.rs
@@ -13,6 +13,7 @@ use luminance::backend::render_gate::RenderGate;
 use luminance::backend::shading_gate::ShadingGate;
 use luminance::backend::tess::Tess;
 use luminance::backend::tess_gate::TessGate;
+use luminance::blending::BlendingMode;
 use luminance::pipeline::{PipelineError, PipelineState, Viewport};
 use luminance::pixel::Pixel;
 use luminance::render_state::RenderState;
@@ -245,8 +246,16 @@ unsafe impl RenderGate for GL33 {
     match rdr_st.blending {
       Some(blending) => {
         gfx_state.set_blending_state(BlendingState::On);
-        gfx_state.set_blending_equation(blending.equation);
-        gfx_state.set_blending_func(blending.src, blending.dst);
+        match blending {
+          BlendingMode::Combined(b) => {
+            gfx_state.set_blending_equation(b.equation);
+            gfx_state.set_blending_func(b.src, b.dst);
+          }
+          BlendingMode::Separate { rgb, alpha } => {
+            gfx_state.set_blending_equation_separate(rgb.equation, alpha.equation);
+            gfx_state.set_blending_func_separate(rgb.src, rgb.dst, alpha.src, alpha.dst);
+          }
+        }
       }
       None => {
         gfx_state.set_blending_state(BlendingState::Off);

--- a/luminance/src/blending.rs
+++ b/luminance/src/blending.rs
@@ -62,11 +62,11 @@ pub enum Factor {
   DstAlpha,
   /// `(1 - dstA) * color`
   DstAlphaComplement,
-  /// This behavior is still not well understood. Dammit.
+  /// For colors, `min(srcA, 1 - dstA)`, for alpha, `1`
   SrcAlphaSaturate,
 }
 
-/// Blending configuration.
+/// Basic blending configuration.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Blending {
   /// Blending equation to use.
@@ -75,4 +75,25 @@ pub struct Blending {
   pub src: Factor,
   /// Destination factor.
   pub dst: Factor,
+}
+
+/// Blending configuration to represent combined or separate options.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BlendingMode {
+  /// Blending with combined RGBA.
+  Combined(Blending),
+
+  /// Blending with RGB and alpha separately.
+  Separate {
+    /// Blending configuration for RGB components.
+    rgb: Blending,
+    /// Blending configuration for alpha component.
+    alpha: Blending,
+  },
+}
+
+impl From<Blending> for BlendingMode {
+  fn from(blending: Blending) -> Self {
+    BlendingMode::Combined(blending)
+  }
 }

--- a/luminance/src/render_state.rs
+++ b/luminance/src/render_state.rs
@@ -3,7 +3,7 @@
 //! Such a state controls how the GPU must operate some fixed pipeline functionality, such as the
 //! blending, depth test or face culling operations.
 
-use crate::blending::Blending;
+use crate::blending::{Blending, BlendingMode};
 use crate::depth_test::DepthComparison;
 use crate::face_culling::FaceCulling;
 
@@ -14,7 +14,7 @@ use crate::face_culling::FaceCulling;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RenderState {
   /// Blending configuration.
-  pub blending: Option<Blending>,
+  pub blending: Option<BlendingMode>,
   /// Depth test configuration.
   pub depth_test: Option<DepthComparison>,
   /// Face culling configuration.
@@ -28,13 +28,24 @@ impl RenderState {
     B: Into<Option<Blending>>,
   {
     RenderState {
-      blending: blending.into(),
+      blending: blending.into().map(|x| x.into()),
+      ..self
+    }
+  }
+
+  /// Override the blending configuration using separate blending.
+  pub fn set_blending_separate(self, blending_rgb: Blending, blending_alpha: Blending) -> Self {
+    RenderState {
+      blending: Some(BlendingMode::Separate {
+        rgb: blending_rgb,
+        alpha: blending_alpha,
+      }),
       ..self
     }
   }
 
   /// Blending configuration.
-  pub fn blending(self) -> Option<Blending> {
+  pub fn blending(self) -> Option<BlendingMode> {
     self.blending
   }
 


### PR DESCRIPTION
There were some choices to be made in the API. I added distinct functions for the 'separate' blending functionality, which has the benefits of (1) compatibility with existing code and (2) matching the OpenGL API. Another choice would be to only expose the 'separate' versions. 