### PR TITLE
Enhance texture unit caching to prevent switching texture units when no texture bind would occur

### DIFF
--- a/luminance-gl/src/gl33/pipeline.rs
+++ b/luminance-gl/src/gl33/pipeline.rs
@@ -189,8 +189,7 @@ where
       unit
     });
 
-    state.set_texture_unit(unit);
-    state.bind_texture(texture.target, texture.handle);
+    state.bind_texture_at(texture.target, texture.handle, unit);
 
     Ok(BoundTexture {
       unit,


### PR DESCRIPTION
# Before

![](https://user-images.githubusercontent.com/506592/85922064-e7a69480-b880-11ea-966a-94959387d158.png)

Notice the `glActiveTexture`, which are texture unit activations — completely useless here.

# After

![](https://i.imgur.com/oUvuJcy.png)