### PR TITLE
Add a fixture to demonstrate #360

### DIFF
--- a/integration-tests/desktop/src/main.rs
+++ b/integration-tests/desktop/src/main.rs
@@ -1,16 +1,16 @@
-mod gl33_f64_uniform;
-mod scissor;
-mod tess_no_data;
-
 use colored::Colorize as _;
 
 macro_rules! tests {
   ($($name:expr, $module:ident),*) => {
-    const TEST_NAMES: &[&str] = &[$(
-      $name
-      ),*
-    ];
+    // declare the modules for all tests
+    $(
+      mod $module;
+    )*
 
+    // list of all available integration tests
+    const TEST_NAMES: &[&str] = &[$( $name ),*];
+
+    // run a given test
     fn run_test(name: &str) {
       $(
         if name == $name {
@@ -33,7 +33,8 @@ macro_rules! tests {
 tests! {
   "gl33-f64-uniform", gl33_f64_uniform,
   "tess-no-data", tess_no_data,
-  "scissor-test", scissor
+  "scissor-test", scissor,
+  "360-manually-drop-framebuffer", manually_drop_framebuffer
 }
 
 fn main() {

--- a/integration-tests/desktop/src/manually_drop_framebuffer.rs
+++ b/integration-tests/desktop/src/manually_drop_framebuffer.rs
@@ -1,0 +1,27 @@
+//! <https://github.com/phaazon/luminance-rs/issues/360>
+//!
+//! When a framebuffer is created, dropped and a new one is created, the new framebuffer doesn’t
+//! seem to behave correctly. At the time of #360, it was detected on Windows.
+//!
+//! Because this example simply creates a framebuffer, drops it and creates another one, nothing is
+//! displayed and the window flashes on the screen. Run the application in a tool such as apitrace
+//! or renderdoc to analyze it.
+
+use luminance::context::GraphicsContext as _;
+use luminance::pixel::{Depth32F, RGBA32F};
+use luminance::texture::{Dim2, Sampler};
+use luminance_glfw::GlfwSurface;
+use luminance_windowing::WindowOpt;
+
+pub fn fixture() {
+  let mut surface =
+    GlfwSurface::new_gl33("fixture-360", WindowOpt::default()).expect("GLFW surface");
+
+  let framebuffer =
+    surface.new_framebuffer::<Dim2, RGBA32F, Depth32F>([1024, 1024], 0, Sampler::default());
+
+  std::mem::drop(framebuffer);
+
+  // #360 occurs here after the drop
+  let _ = surface.new_framebuffer::<Dim2, RGBA32F, Depth32F>([1024, 1024], 0, Sampler::default());
+}


### PR DESCRIPTION
# Last analysis

On Archlinux, I don’t reproduce with the following setup:

```toml
[dependencies]
image = "0.23"
luminance = "0.40"
luminance-derive = "0.6"
luminance-glfw = "0.13"
luminance-glutin = "0.10"
luminance-windowing = "0.9"
glfw = "0.39"
glutin = "0.24"
```

```
λ uname -a
Linux orchid 5.7.2-arch1-1 #1 SMP PREEMPT Wed, 10 Jun 2020 20:36:24 +0000 x86_64 GNU/Linux

λ glxinfo | rg OpenGL
OpenGL vendor string: NVIDIA Corporation
OpenGL renderer string: GeForce RTX 2070/PCIe/SSE2
OpenGL core profile version string: 4.6.0 NVIDIA 440.82
OpenGL core profile shading language version string: 4.60 NVIDIA
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile
OpenGL core profile extensions:
OpenGL version string: 4.6.0 NVIDIA 440.82
OpenGL shading language version string: 4.60 NVIDIA
OpenGL context flags: (none)
OpenGL profile mask: (none)
OpenGL extensions:
OpenGL ES profile version string: OpenGL ES 3.2 NVIDIA 440.82
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
OpenGL ES profile extensions:

λ pacman -Qi mesa
Name            : mesa
Version         : 20.1.1-1
Description     : An open-source implementation of the OpenGL specification
Architecture    : x86_64
URL             : https://www.mesa3d.org/
Licenses        : custom
Groups          : None
Provides        : mesa-libgl  opengl-driver
Depends On      : libdrm  wayland  libxxf86vm  libxdamage  libxshmfence  libelf  libomxil-bellagio  libunwind  llvm-libs  lm_sensors
                  libglvnd  zstd
Optional Deps   : opengl-man-pages: for the OpenGL API man pages
                  mesa-vdpau: for accelerated video playback
                  libva-mesa-driver: for accelerated video playback
Required By     : gst-plugins-base-libs  gtk3  lib32-mesa  libglvnd  qt5-base  slop  xorg-server-devel
Optional For    : None
Conflicts With  : mesa-libgl
Replaces        : mesa-libgl
Installed Size  : 84.73 MiB
Packager        : Laurent Carlier <lordheavym@gmail.com>
Build Date      : Wed 10 Jun 2020 08:49:21 PM CEST
Install Date    : Mon 15 Jun 2020 04:18:15 PM CEST
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature
```

![img_070720_103727](https://user-images.githubusercontent.com/506592/86751871-40bfb680-c03f-11ea-99b6-de9a746288d3.png)
