### PR TITLE
Implement type-safe texture uploads for f32, u8-32, and i8-32

### DIFF
--- a/luminance-webgl/src/webgl2.rs
+++ b/luminance-webgl/src/webgl2.rs
@@ -1,5 +1,5 @@
 //! WebGL 2.0 backend support.
-
+mod array_buffer;
 pub mod buffer;
 pub mod framebuffer;
 pub mod pipeline;
@@ -9,6 +9,7 @@ pub(crate) mod state;
 pub mod tess;
 pub mod texture;
 
+pub use crate::webgl2::array_buffer::IntoArrayBuffer;
 pub use crate::webgl2::state::StateQueryError;
 use crate::webgl2::state::WebGL2State;
 use std::cell::RefCell;

--- a/luminance-webgl/src/webgl2/array_buffer.rs
+++ b/luminance-webgl/src/webgl2/array_buffer.rs
@@ -2,9 +2,9 @@
 ///
 /// This is an unsafe operation, as <$buffer>::view() requires that the underlying memory not be moved until the Array Buffer is dropped.
 ///
-/// Primitives: u8, i8, u16, i16, u32, i32, f32, f64
+/// Supported primitives: u8, i8, u16, i16, u32, i32, f32, f64
 ///
-/// Tuples: T, (T, T), (T, T, T), and (T, T, T, T)
+/// Supported tuples: T, (T, T), (T, T, T), and (T, T, T, T)
 pub trait IntoArrayBuffer: Sized {
   unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object;
 }
@@ -33,10 +33,8 @@ macro_rules! impl_tuple_IntoArrayBuffer {
 
     impl IntoArrayBuffer for $tuple {
       unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object {
-        let slice = std::slice::from_raw_parts(
-          texels.as_ptr() as *const $t,
-          texels.len() * $n * std::mem::size_of::<$tuple>(),
-        );
+        let slice: &[$t] =
+          std::slice::from_raw_parts(texels.as_ptr() as *const $t, texels.len() * $n);
 
         <$buffer>::view(slice).into()
       }

--- a/luminance-webgl/src/webgl2/array_buffer.rs
+++ b/luminance-webgl/src/webgl2/array_buffer.rs
@@ -1,11 +1,17 @@
-/// Implemented for Encoding and RawEncoding primitives which can be cast into a js_sys ArrayBuffer.
+//! A collection of utilities used to perform conversion between immutable slices and JavaScript’s
+//! various array types.
+
+/// Unsafe coercion to a `js_sys::Object` for immutable slices.
 ///
-/// This is an unsafe operation, as <$buffer>::view() requires that the underlying memory not be moved until the Array Buffer is dropped.
-///
-/// Supported primitives: u8, i8, u16, i16, u32, i32, f32, f64
-///
-/// Supported tuples: T, (T, T), (T, T, T), and (T, T, T, T)
+/// This trait exports the [`into_array_buffer`], which is an unsafe operation, as
+/// the `view()` method, defined on the various arrays in the `js-sys` crate, requires that the
+/// underlying memory not be moved until the array is dropped.
 pub trait IntoArrayBuffer: Sized {
+  /// Convert the input slice into a JavaScript object.
+  ///
+  /// # Unsafety
+  ///
+  /// The returned `Object` must not outlive the input slice, which memory must not be moved either.
   unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object;
 }
 

--- a/luminance-webgl/src/webgl2/array_buffer.rs
+++ b/luminance-webgl/src/webgl2/array_buffer.rs
@@ -1,0 +1,55 @@
+/// Implemented for Encoding and RawEncoding primitives which can be cast into a js_sys ArrayBuffer.
+///
+/// This is an unsafe operation, as <$buffer>::view() requires that the underlying memory not be moved until the Array Buffer is dropped.
+///
+/// Primitives: u8, i8, u16, i16, u32, i32, f32, f64
+///
+/// Tuples: T, (T, T), (T, T, T), and (T, T, T, T)
+pub trait IntoArrayBuffer: Sized {
+  unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object;
+}
+
+macro_rules! impl_IntoArrayBuffer {
+  ($t:ty, $buffer:ty) => {
+    impl IntoArrayBuffer for $t {
+      unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object {
+        <$buffer>::view(texels).into()
+      }
+    }
+
+    impl_tuple_IntoArrayBuffer!($t, ($t, $t), 2, $buffer);
+    impl_tuple_IntoArrayBuffer!($t, ($t, $t, $t), 3, $buffer);
+    impl_tuple_IntoArrayBuffer!($t, ($t, $t, $t, $t), 4, $buffer);
+  };
+}
+
+macro_rules! impl_tuple_IntoArrayBuffer {
+  ($t:ty, $tuple:ty, $n:literal, $buffer:ty) => {
+    // statically assert that [T; 3] has the same size as (T, T, T)
+    // this checks that the from_raw_parts cast has the correct value for $n and $tuple
+    const _: fn() = || {
+      let _ = std::mem::transmute::<[$t; $n], $tuple>;
+    };
+
+    impl IntoArrayBuffer for $tuple {
+      unsafe fn into_array_buffer(texels: &[Self]) -> js_sys::Object {
+        let slice = std::slice::from_raw_parts(
+          texels.as_ptr() as *const $t,
+          texels.len() * $n * std::mem::size_of::<$tuple>(),
+        );
+
+        <$buffer>::view(slice).into()
+      }
+    }
+  };
+}
+
+impl_IntoArrayBuffer!(u8, js_sys::Uint8Array);
+impl_IntoArrayBuffer!(i8, js_sys::Int8Array);
+impl_IntoArrayBuffer!(u16, js_sys::Uint16Array);
+impl_IntoArrayBuffer!(i16, js_sys::Int16Array);
+impl_IntoArrayBuffer!(u32, js_sys::Uint32Array);
+impl_IntoArrayBuffer!(i32, js_sys::Int32Array);
+
+impl_IntoArrayBuffer!(f32, js_sys::Float32Array);
+impl_IntoArrayBuffer!(f64, js_sys::Float64Array);

--- a/luminance-webgl/src/webgl2/pipeline.rs
+++ b/luminance-webgl/src/webgl2/pipeline.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use web_sys::WebGl2RenderingContext;
 
+use super::array_buffer::IntoArrayBuffer;
 use crate::webgl2::state::{BlendingState, DepthTest, FaceCullingState, WebGL2State};
 use crate::webgl2::WebGL2;
 
@@ -165,6 +166,8 @@ unsafe impl<D, P> PipelineTexture<D, P> for WebGL2
 where
   D: Dimensionable,
   P: Pixel,
+  P::Encoding: IntoArrayBuffer,
+  P::RawEncoding: IntoArrayBuffer,
 {
   type BoundTextureRepr = BoundTexture<D, P>;
 

--- a/luminance-webgl/src/webgl2/texture.rs
+++ b/luminance-webgl/src/webgl2/texture.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::slice;
 use web_sys::{WebGl2RenderingContext, WebGlTexture};
 
-use super::array_buffer::IntoArrayBuffer;
+use crate::webgl2::array_buffer::IntoArrayBuffer;
 use crate::webgl2::pixel::webgl_pixel_format;
 use crate::webgl2::state::WebGL2State;
 use crate::webgl2::WebGL2;
@@ -570,6 +570,8 @@ where
   let skip_bytes = (D::width(size) as usize * pf_size) % 8;
   set_unpack_alignment(state, skip_bytes);
 
+  // coerce the texels slice into a web-sys array buffer so that we can pass them to the super ugly
+  // method below
   let array_buffer;
   unsafe {
     array_buffer = T::into_array_buffer(texels);
@@ -578,9 +580,6 @@ where
   match webgl_pixel_format(pf) {
     Some((format, _, encoding)) => match D::dim() {
       Dim::Dim2 => {
-        // if pf.encoding == Type::Floating {
-        //   let texels = texels.iter().map(|e| e as f32)
-        // }
         state
           .ctx
           .tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_array_buffer_view_and_src_offset(


### PR DESCRIPTION
Add a **public** trait `luminance_webgl::webgl2::IntoArrayBuffer`, which can convert a slice of texels into a `js_sys::*ArrayBuffer` (e.g. `Uint8ArrayBuffer`).  

This allows TextureBackend::upload_texels to provide type-safe webgl array buffers, where P::RawEncoding and P::Encoding implement IntoArrayBuffer.  As mentioned in #385, this fixes texture uploads for floating-point types, as well as some WebGL warnings.  I tested the fix with RGBA uploads of `&[u8]`, `&[f32]`, and `&[(f32, f32, f32, f32)]`.

I also noticed that `create_texture_2d_storage` can be simplified - as `WebGl2RenderingContext` provides a `tex_storage_2d` method that creates all the mipmaps in a single call.  I made a similar change for `create_texture_3d_storage`, but left the cubemap function alone.

I think there are a few things to consider:
- `IntoArrayBuffer` needs to be public, otherwise users can't write texture handling code that is generic over `<P: Pixel>`.  I looked for ways to hide it, but couldn't find anything decent.
- `into_array_buffer()` is an unsafe function, for two reasons.  One is that `Uint8ArrayBuffer::view(&[u8])` is unsafe function, as it leaks a reference to the underlying array.  Two is that I use `std::slice::from_raw_parts` to cast tuples: e.g. `&[(T, T)]` down to `&[T]`.  I found a way to statically assert that [T; 3] and (T, T, T) have the same size, to catch any mistakes in the macro invocation.
- If you like one part or another (IntoArrayBuffer vs create_texture_2d), I can split the PR.

This is a reasonably sized change, so let me know if you have any comments!