### PR TITLE
WIP: Add ability to scissor geometry via RenderState

### DIFF
--- a/integration-tests/desktop/fixtures/src/main.rs
+++ b/integration-tests/desktop/fixtures/src/main.rs
@@ -1,4 +1,5 @@
 mod gl33_f64_uniform;
+mod scissor;
 mod tess_no_data;
 
 use colored::Colorize as _;
@@ -18,9 +19,10 @@ macro_rules! fixture {
   };
 }
 fn main() {
-  fixture!("Tess with no data should generate an error", tess_no_data);
-  fixture!(
-    "Double-precision floating point uniforms support",
-    gl33_f64_uniform
-  );
+  // fixture!("Tess with no data should generate an error", tess_no_data);
+  // fixture!(
+  //   "Double-precision floating point uniforms support",
+  //   gl33_f64_uniform
+  // );
+  fixture!("Scissor test", scissor);
 }

--- a/integration-tests/desktop/fixtures/src/tess_no_data.rs
+++ b/integration-tests/desktop/fixtures/src/tess_no_data.rs
@@ -1,11 +1,10 @@
-use luminance_front::context::GraphicsContext;
+use luminance_front::context::GraphicsContext as _;
 use luminance_front::tess::TessError;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::WindowOpt;
 
 pub fn fixture() -> bool {
-  let mut surface =
-    GlfwSurface::new_gl33("GL_ARB_gpu_shader_fp64 test", WindowOpt::default()).unwrap();
+  let mut surface = GlfwSurface::new_gl33("Tess no data", WindowOpt::default()).unwrap();
   let tess = surface.new_tess().build();
 
   if let Err(TessError::NoData) = tess {

--- a/luminance-webgl/src/webgl2/pipeline.rs
+++ b/luminance-webgl/src/webgl2/pipeline.rs
@@ -18,9 +18,11 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use web_sys::WebGl2RenderingContext;
 
-use super::array_buffer::IntoArrayBuffer;
-use crate::webgl2::state::{BlendingState, DepthTest, FaceCullingState, WebGL2State};
-use crate::webgl2::WebGL2;
+use crate::webgl2::{
+  array_buffer::IntoArrayBuffer,
+  state::{BlendingState, DepthTest, FaceCullingState, ScissorState, WebGL2State},
+  WebGL2,
+};
 
 pub struct Pipeline {
   state: Rc<RefCell<WebGL2State>>,
@@ -123,6 +125,18 @@ where
       } else {
         0
       };
+
+      // scissor test
+      match pipeline_state.scissor() {
+        Some(region) => {
+          state.set_scissor_state(ScissorState::On);
+          state.set_scissor_region(region);
+        }
+
+        None => {
+          state.set_scissor_state(ScissorState::Off);
+        }
+      }
 
       state.ctx.clear(color_bit | depth_bit);
     }
@@ -257,6 +271,7 @@ unsafe impl RenderGate for WebGL2 {
           }
         }
       }
+
       None => {
         state.set_blending_state(BlendingState::Off);
       }
@@ -281,6 +296,18 @@ unsafe impl RenderGate for WebGL2 {
       }
       None => {
         state.set_face_culling_state(FaceCullingState::Off);
+      }
+    }
+
+    // scissor test
+    match rdr_st.scissor() {
+      Some(region) => {
+        state.set_scissor_state(ScissorState::On);
+        state.set_scissor_region(region);
+      }
+
+      None => {
+        state.set_scissor_state(ScissorState::Off);
       }
     }
   }

--- a/luminance/src/lib.rs
+++ b/luminance/src/lib.rs
@@ -192,6 +192,7 @@ pub mod pipeline;
 pub mod pixel;
 pub mod render_gate;
 pub mod render_state;
+pub mod scissor_region;
 pub mod shader;
 pub mod shading_gate;
 pub mod tess;

--- a/luminance/src/lib.rs
+++ b/luminance/src/lib.rs
@@ -192,7 +192,7 @@ pub mod pipeline;
 pub mod pixel;
 pub mod render_gate;
 pub mod render_state;
-pub mod scissor_region;
+pub mod scissor;
 pub mod shader;
 pub mod shading_gate;
 pub mod tess;

--- a/luminance/src/render_state.rs
+++ b/luminance/src/render_state.rs
@@ -23,7 +23,7 @@ pub struct RenderState {
   /// Face culling configuration.
   face_culling: Option<FaceCulling>,
   /// Scissor region configuration.
-  scissor_region: Option<ScissorRegion>,
+  scissor: Option<ScissorRegion>,
 }
 
 impl RenderState {
@@ -97,20 +97,20 @@ impl RenderState {
     self.face_culling
   }
 
-  /// Override the scissor region configuration.
-  pub fn set_scissor_region<SR>(self, scissor_region: SR) -> Self
+  /// Override the scissor configuration.
+  pub fn set_scissor<SR>(self, scissor: SR) -> Self
   where
     SR: Into<Option<ScissorRegion>>,
   {
     RenderState {
-      scissor_region: scissor_region.into(),
+      scissor: scissor.into(),
       ..self
     }
   }
 
-  /// Scissor region configuration.
-  pub fn scissor_region(self) -> Option<ScissorRegion> {
-    self.scissor_region
+  /// Get the scissor configuration.
+  pub fn scissor(&self) -> &Option<ScissorRegion> {
+    &self.scissor
   }
 }
 
@@ -128,7 +128,7 @@ impl Default for RenderState {
       depth_test: Some(DepthComparison::Less),
       depth_write: DepthWrite::On,
       face_culling: None,
-      scissor_region: None,
+      scissor: None,
     }
   }
 }

--- a/luminance/src/render_state.rs
+++ b/luminance/src/render_state.rs
@@ -6,6 +6,7 @@
 use crate::blending::{Blending, BlendingMode};
 use crate::depth_test::{DepthComparison, DepthWrite};
 use crate::face_culling::FaceCulling;
+use crate::scissor::ScissorRegion;
 
 /// GPU render state.
 ///
@@ -21,6 +22,8 @@ pub struct RenderState {
   depth_write: DepthWrite,
   /// Face culling configuration.
   face_culling: Option<FaceCulling>,
+  /// Scissor region configuration.
+  scissor_region: Option<ScissorRegion>,
 }
 
 impl RenderState {
@@ -93,6 +96,22 @@ impl RenderState {
   pub fn face_culling(&self) -> Option<FaceCulling> {
     self.face_culling
   }
+
+  /// Override the scissor region configuration.
+  pub fn set_scissor_region<SR>(self, scissor_region: SR) -> Self
+  where
+    SR: Into<Option<ScissorRegion>>,
+  {
+    RenderState {
+      scissor_region: scissor_region.into(),
+      ..self
+    }
+  }
+
+  /// Scissor region configuration.
+  pub fn scissor_region(self) -> Option<ScissorRegion> {
+    self.scissor_region
+  }
 }
 
 impl Default for RenderState {
@@ -102,12 +121,14 @@ impl Default for RenderState {
   ///   - `depth_test`: `Some(DepthComparison::Less)`
   ///   - `depth_write`: `DepthWrite::On`
   ///   - `face_culling`: `None`
+  ///   - 'scissor_region`: `None`
   fn default() -> Self {
     RenderState {
       blending: None,
       depth_test: Some(DepthComparison::Less),
       depth_write: DepthWrite::On,
       face_culling: None,
+      scissor_region: None,
     }
   }
 }

--- a/luminance/src/scissor.rs
+++ b/luminance/src/scissor.rs
@@ -1,0 +1,20 @@
+//! Scissor test and related types.
+//!
+//! The scissor test is a special test performed at rendering time. It allows to define a region of the screen for which
+//! fragments will be discarded.
+
+/// The region outside of which fragments will be discarded.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ScissorRegion {
+  /// The x screen position of the scissor region.
+  pub x: u32,
+
+  /// The y screen position of the scissor region.
+  pub y: u32,
+
+  /// The screen width of the scissor region.
+  pub width: u32,
+
+  /// The screen height of the scissor region.
+  pub height: u32,
+}


### PR DESCRIPTION
This PR allows the user to apply a scissor region to drawn geometry using gl::Scissor internally to produce effects like the following.

![Screenshot from 2020-07-12 00-42-30](https://user-images.githubusercontent.com/3239951/87239093-05274280-c3d9-11ea-8d59-5aa12e9cfc8d.png)