### PR TITLE
Preserve the default type for Tess and TessBuilder.

### DIFF
--- a/luminance-front/src/tess.rs
+++ b/luminance-front/src/tess.rs
@@ -5,8 +5,9 @@ pub use luminance::tess::{
   TessViewError,
 };
 
-pub type TessBuilder<'a, V, I, W, S> = luminance::tess::TessBuilder<'a, Backend, V, I, W, S>;
-pub type Tess<V, I, W, S> = luminance::tess::Tess<Backend, V, I, W, S>;
+pub type TessBuilder<'a, V, I = (), W = (), S = Interleaved> =
+  luminance::tess::TessBuilder<'a, Backend, V, I, W, S>;
+pub type Tess<V, I = (), W = (), S = Interleaved> = luminance::tess::Tess<Backend, V, I, W, S>;
 pub type Vertices<V, I, W, S, T> = luminance::tess::Vertices<Backend, V, I, W, S, T>;
 pub type VerticesMut<V, I, W, S, T> = luminance::tess::VerticesMut<Backend, V, I, W, S, T>;
 pub type Indices<V, I, W, S> = luminance::tess::Indices<Backend, V, I, W, S>;


### PR DESCRIPTION
This resolves the discrepancy of `luminance-front` from `luminance` by specifying default concrete types for the generic type parameters of `Tess` and `TessBuilder`.
https://github.com/phaazon/luminance-rs/blob/65a31ab6761ca74dfcf5f13ac343fb2253268e20/luminance/src/tess.rs#L893
https://github.com/phaazon/luminance-rs/blob/65a31ab6761ca74dfcf5f13ac343fb2253268e20/luminance-front/src/tess.rs#L9
https://github.com/phaazon/luminance-rs/blob/65a31ab6761ca74dfcf5f13ac343fb2253268e20/luminance/src/tess.rs#L517
https://github.com/phaazon/luminance-rs/blob/65a31ab6761ca74dfcf5f13ac343fb2253268e20/luminance-front/src/tess.rs#L8