### PR TITLE
[luminance] Add `PartialEq` and `Eq` derives to applicable public enums.

### DIFF
--- a/luminance/src/pipeline.rs
+++ b/luminance/src/pipeline.rs
@@ -243,7 +243,7 @@ use crate::texture::Texture;
 
 /// Possible errors that might occur in a graphics [`Pipeline`].
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum PipelineError {}
 
 impl fmt::Display for PipelineError {

--- a/luminance/src/shader.rs
+++ b/luminance/src/shader.rs
@@ -178,7 +178,7 @@ impl fmt::Display for StageType {
 
 /// Errors that shader stages can emit.
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StageError {
   /// Occurs when a shader fails to compile.
   CompilationFailed(StageType, String),
@@ -240,7 +240,7 @@ where
 
 /// Errors that a [`Program`] can generate.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ProgramError {
   /// Creating the program failed.
   CreationFailed(String),
@@ -298,7 +298,7 @@ impl error::Error for ProgramError {
 }
 
 /// Program warnings, not necessarily considered blocking errors.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ProgramWarning {
   /// Some uniform configuration is ill-formed. It can be a problem of inactive uniform, mismatch
   /// type, etc. Check the [`UniformWarning`] type for more information.
@@ -333,7 +333,7 @@ impl From<ProgramWarning> for ProgramError {
 
 /// Warnings related to uniform issues.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum UniformWarning {
   /// Inactive uniform (not in use / no participation to the final output in shaders).
   Inactive(String),
@@ -403,7 +403,7 @@ impl error::Error for UniformWarning {}
 
 /// Warnings related to vertex attributes issues.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum VertexAttribWarning {
   /// Inactive vertex attribute (not read).
   Inactive(String),

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -95,7 +95,7 @@ use crate::vertex::{Deinterleave, Vertex, VertexDesc};
 /// restart index_ with [`TessBuilder::set_primitive_restart_index`]. Whenever a vertex index is set
 /// to the same value as the _primitive restart index_, the value is not interpreted as a vertex
 /// index but just a marker / hint to start a new primitive.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Mode {
   /// A single point.
   ///
@@ -249,7 +249,7 @@ impl error::Error for TessMapError {
 
 /// Possible errors that might occur when dealing with [`Tess`].
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum TessError {
   /// Cannot create a tessellation.
   CannotCreate(String),
@@ -1254,7 +1254,7 @@ where
 
 /// Possible error that might occur while dealing with [`TessView`] objects.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum TessViewError {
   /// The view has incorrect size.
   ///

--- a/luminance/src/texture.rs
+++ b/luminance/src/texture.rs
@@ -39,7 +39,7 @@ use crate::depth_test::DepthComparison;
 use crate::pixel::{Pixel, PixelFormat};
 
 /// How to wrap texture coordinates while sampling textures?
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Wrap {
   /// If textures coordinates lay outside of *[0;1]*, they will be clamped to either *0* or *1* for
   /// every components.
@@ -56,7 +56,7 @@ pub enum Wrap {
 }
 
 /// Minification filter.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MinFilter {
   /// Nearest interpolation.
   Nearest,
@@ -77,7 +77,7 @@ pub enum MinFilter {
 }
 
 /// Magnification filter.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MagFilter {
   /// Nearest interpolation.
   Nearest,
@@ -133,7 +133,7 @@ pub trait Dimensionable {
 }
 
 /// Dimension of a texture.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Dim {
   /// 1D.
   Dim1,
@@ -319,7 +319,7 @@ impl Dimensionable for Cubemap {
 }
 
 /// Faces of a cubemap.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CubeFace {
   /// The +X face of the cube.
   PositiveX,


### PR DESCRIPTION
This PR adds `PartialEq` and `Eq` derives to public enums where applicable.

The `luminance-glfw` crate also had some enums that didn't have this derive, but I wasn't able to build the crate (due to not having glfw installed on my machine) in order to do a `cargo check`, so I didn't add any derives in case one of the variants doesn't implement it.

I haven't opened an issue, as this is a relatively simple change that doesn't affect much, I believe.