### PR TITLE
Fixed a problem with the Wasm Example

### DIFF
--- a/luminance-examples-web/shaders/simple-fs.glsl
+++ b/luminance-examples-web/shaders/simple-fs.glsl
@@ -1,0 +1,7 @@
+in vec3 v_color;
+
+out vec4 frag;
+
+void main() {
+  frag = vec4(v_color, 1.);
+}

--- a/luminance-examples-web/shaders/simple-vs.glsl
+++ b/luminance-examples-web/shaders/simple-vs.glsl
@@ -1,0 +1,9 @@
+in vec2 co;
+in uvec3 color;
+
+out vec3 v_color;
+
+void main() {
+  gl_Position = vec4(co, 0., 1.);
+  v_color = vec3(color.rgb);
+}

--- a/luminance-examples-web/src/lib.rs
+++ b/luminance-examples-web/src/lib.rs
@@ -18,8 +18,8 @@ use luminance_web_sys::WebSysWebGL2Surface;
 use wasm_bindgen::prelude::*;
 
 // We get the shader at compile time from local files
-const VS: &'static str = include_str!("../../luminance-examples/src/simple-vs.glsl");
-const FS: &'static str = include_str!("../../luminance-examples/src/simple-fs.glsl");
+const VS: &'static str = include_str!("../shaders/simple-vs.glsl");
+const FS: &'static str = include_str!("../shaders/simple-fs.glsl");
 
 // Vertex semantics. Those are needed to instruct the GPU how to select vertex’s attributes from
 // the memory we fill at render time, in shaders. You don’t have to worry about them; just keep in


### PR DESCRIPTION
I recently tried setting up `luminance-rs` in one of my projects but had trouble because of this issue. It took a while to figure it out.

The the issue is:-
In `luminance-examples-web/src/lib.rs` where you have defined the `Semantics` enum, you have defined the `VertexColor` struct (with the `sem` macro) with data type `[u8; 3]` and have mentioned in the comment that it is represented by `uvec3` data-type in GLSL. But, in the Vertex Shader you have taken `vec3` as input. Because of this the code doesn't work.

I have copied the vertex and fragment shaders to `luminance-examples-web/shaders/` with the required changes. I could'hv edited the original shaders but didn't do so because I thought they might be used somewhere else also.