### PR TITLE
Add luminance_sdl2::GL33Surface::window_mut.

### DIFF
--- a/luminance-sdl2/src/lib.rs
+++ b/luminance-sdl2/src/lib.rs
@@ -133,9 +133,14 @@ impl GL33Surface {
     &self.sdl
   }
 
-  /// The underlying SDL2 window of this surface.
+  /// Borrow the underlying SDL2 window of this surface.
   pub fn window(&self) -> &sdl2::video::Window {
     &self.window
+  }
+
+  /// Mutably borrow the underlying SDL2 window of this surface.
+  pub fn window_mut(&mut self) -> &mut sdl2::video::Window {
+    &mut self.window
   }
 
   /// Get the back buffer.


### PR DESCRIPTION
There was previously no way of getting a mutable borrow of the underlying window, preventing use of mutating methods such as `Window::hide`, `Window::set_title` and others.