### PR TITLE
Update calls to deprecated method `to_rgb()`

### DIFF
--- a/luminance-examples/src/displacement-map.rs
+++ b/luminance-examples/src/displacement-map.rs
@@ -51,7 +51,7 @@ fn main() {
   let texture_image = image::open(&texture_path)
     .expect("Could not load image from path")
     .flipv()
-    .to_rgb();
+    .to_rgb8();
   let (width, height) = texture_image.dimensions();
 
   let displacement_map_1 = image::load_from_memory_with_format(
@@ -59,14 +59,14 @@ fn main() {
     image::ImageFormat::Png,
   )
   .expect("Could not load displacement map")
-  .to_rgb();
+  .to_rgb8();
 
   let displacement_map_2 = image::load_from_memory_with_format(
     include_bytes!("./displacement-map-resources/displacement_2.png"),
     image::ImageFormat::Png,
   )
   .expect("Could not load displacement map")
-  .to_rgb();
+  .to_rgb8();
 
   let dim = WindowDim::Windowed { width, height };
   let surface = GlfwSurface::new_gl33("Displacement Map", WindowOpt::default().set_dim(dim))

--- a/luminance-examples/src/skybox.rs
+++ b/luminance-examples/src/skybox.rs
@@ -483,7 +483,7 @@ fn upload_cubemap(
   context: &mut impl GraphicsContext<Backend = Backend>,
   img: &image::DynamicImage,
 ) -> Result<Texture<Cubemap, NormRGB8UI>, AppError> {
-  let img = img.to_rgb();
+  let img = img.to_rgb8();
 
   let width = img.width();
   let size = width / 4;

--- a/luminance-examples/src/texture.rs
+++ b/luminance-examples/src/texture.rs
@@ -132,7 +132,7 @@ fn run(texture_path: &Path) {
 
 // read the texture into memory as a whole bloc (i.e. no streaming)
 fn read_image(path: &Path) -> Option<image::RgbImage> {
-  image::open(path).map(|img| img.flipv().to_rgb()).ok()
+  image::open(path).map(|img| img.flipv().to_rgb8()).ok()
 }
 
 fn load_from_disk<B>(context: &mut B, img: image::RgbImage) -> Texture<B::Backend, Dim2, NormRGB8UI>


### PR DESCRIPTION
The method `DynamicImage#to_rgb()` is deprecated; this PR updates invocation to the current method `to_rgb8()`.