### PR TITLE
Implement texture resizing.

### DIFF
--- a/luminance-examples/Cargo.toml
+++ b/luminance-examples/Cargo.toml
@@ -64,6 +64,10 @@ name = "texture"
 path = "src/texture.rs"
 
 [[bin]]
+name = "texture-resize"
+path = "src/texture_resize.rs"
+
+[[bin]]
 name = "vertex-instancing"
 path = "src/vertex-instancing.rs"
 

--- a/luminance-examples/src/texture_resize.rs
+++ b/luminance-examples/src/texture_resize.rs
@@ -1,0 +1,184 @@
+//! This program is a showcase to demonstrate how you can use texture from an image loaded from the
+//! disk and re-use it to load another image with a different size.
+//!
+//! Two texture paths are read from the command line interface and are the sole arguments.
+//!
+//! For the purpose of simplicity, the images ares stretched to match your window resolution.
+//!
+//! Press <space> to switch to the other image.
+//! Press <escape> to quit or close the window.
+//!
+//! > Note: for this example, it is recommended to compile with --release to speed up image loading.
+//!
+//! https://docs.rs/luminance
+
+use glfw::{Action, Context as _, Key, WindowEvent};
+use luminance::backend::texture::Texture as TextureBackend;
+use luminance::blending::{Blending, Equation, Factor};
+use luminance::context::GraphicsContext;
+use luminance::pipeline::{PipelineState, TextureBinding};
+use luminance::pixel::{NormRGB8UI, NormUnsigned};
+use luminance::render_state::RenderState;
+use luminance::shader::Uniform;
+use luminance::tess::Mode;
+use luminance::texture::{Dim2, GenMipmaps, Sampler, Texture};
+use luminance::UniformInterface;
+use luminance_glfw::GlfwSurface;
+use luminance_windowing::{WindowDim, WindowOpt};
+use std::env; // used to get the CLI arguments
+use std::path::Path;
+
+const VS: &'static str = include_str!("texture-vs.glsl");
+const FS: &'static str = include_str!("texture-fs.glsl");
+
+fn main() {
+  let texture_paths: Vec<_> = env::args().skip(1).collect();
+  if texture_paths.len() == 2 {
+    run(Path::new(&texture_paths[0]), Path::new(&texture_paths[1]));
+  } else {
+    eprintln!("missing texture paths");
+  }
+}
+
+// we also need a special uniform interface here to pass the texture to the shader
+#[derive(UniformInterface)]
+struct ShaderInterface {
+  tex: Uniform<TextureBinding<Dim2, NormUnsigned>>,
+}
+
+fn run(texture_path: &Path, texture_path2: &Path) {
+  let img = read_image(texture_path).expect("error while reading first image on disk");
+  let img2 = read_image(texture_path2).expect("error while reading second image on disk");
+  let mut current_image = 0;
+  let (width, height) = img.dimensions();
+  let images = [img, img2];
+
+  let dim = WindowDim::Windowed { width, height };
+  let surface = GlfwSurface::new_gl33("Hello, world!", WindowOpt::default().set_dim(dim))
+    .expect("GLFW surface creation");
+  let mut context = surface.context;
+  let events = surface.events_rx;
+
+  let mut tex = load_from_disk(&mut context, &images[0]);
+
+  // set the uniform interface to our type so that we can read textures from the shader
+  let mut program = context
+    .new_shader_program::<(), (), ShaderInterface>()
+    .from_strings(VS, None, None, FS)
+    .expect("program creation")
+    .ignore_warnings();
+
+  // we’ll use an attributeless render here to display a quad on the screen (two triangles); there
+  // are over ways to cover the whole screen but this is easier for you to understand; the
+  // TriangleFan creates triangles by connecting the third (and next) vertex to the first one
+  let tess = context
+    .new_tess()
+    .set_vertex_nb(4)
+    .set_mode(Mode::TriangleFan)
+    .build()
+    .unwrap();
+
+  let mut back_buffer = context.back_buffer().unwrap();
+  let render_st = &RenderState::default().set_blending(Blending {
+    equation: Equation::Additive,
+    src: Factor::SrcAlpha,
+    dst: Factor::Zero,
+  });
+
+  println!("rendering!");
+
+  'app: loop {
+    context.window.glfw.poll_events();
+    for (_, event) in glfw::flush_messages(&events) {
+      match event {
+        WindowEvent::Close | WindowEvent::Key(Key::Escape, _, Action::Release, _) => break 'app,
+
+        WindowEvent::FramebufferSize(..) => {
+          back_buffer = context.back_buffer().unwrap();
+        }
+
+        WindowEvent::Key(Key::Space, _, Action::Release, _) => {
+          // reload the image
+          current_image = 1 - current_image;
+          reload_image(&images[current_image], &mut tex);
+        }
+
+        _ => (),
+      }
+    }
+
+    // here, we need to bind the pipeline variable; it will enable us to bind the texture to the GPU
+    // and use it in the shader
+    let render = context
+      .new_pipeline_gate()
+      .pipeline(
+        &back_buffer,
+        &PipelineState::default(),
+        |pipeline, mut shd_gate| {
+          // bind our fancy texture to the GPU: it gives us a bound texture we can use with the shader
+          let bound_tex = pipeline.bind_texture(&mut tex)?;
+
+          shd_gate.shade(&mut program, |mut iface, uni, mut rdr_gate| {
+            // update the texture; strictly speaking, this update doesn’t do much: it just tells the GPU
+            // to use the texture passed as argument (no allocation or copy is performed)
+            iface.set(&uni.tex, bound_tex.binding());
+
+            rdr_gate.render(render_st, |mut tess_gate| {
+              // render the tessellation to the surface the regular way and let the vertex shader’s
+              // magic do the rest!
+              tess_gate.render(&tess)
+            })
+          })
+        },
+      )
+      .assume();
+
+    if render.is_ok() {
+      context.window.swap_buffers();
+    } else {
+      break 'app;
+    }
+  }
+}
+
+// read the texture into memory as a whole bloc (i.e. no streaming)
+fn read_image(path: &Path) -> Option<image::RgbImage> {
+  image::open(path).map(|img| img.flipv().to_rgb8()).ok()
+}
+
+fn load_from_disk<B>(
+  context: &mut B,
+  img: &image::RgbImage,
+) -> Texture<B::Backend, Dim2, NormRGB8UI>
+where
+  B: GraphicsContext,
+  B::Backend: TextureBackend<Dim2, NormRGB8UI>,
+{
+  let (width, height) = img.dimensions();
+  let texels = img.as_raw();
+
+  // create the luminance texture; the third argument is the number of mipmaps we want (leave it
+  // to 0 for now) and the latest is the sampler to use when sampling the texels in the
+  // shader (we’ll just use the default one)
+  let mut tex = context
+    .new_texture([width, height], 0, Sampler::default())
+    .expect("luminance texture creation");
+
+  // the first argument disables mipmap generation (we don’t care so far)
+  tex.upload_raw(GenMipmaps::No, &texels).unwrap();
+
+  tex
+}
+
+fn reload_image(
+  img: &image::RgbImage,
+  tex: &mut Texture<impl TextureBackend<Dim2, NormRGB8UI>, Dim2, NormRGB8UI>,
+) {
+  let (width, height) = img.dimensions();
+  let texels = img.as_raw();
+
+  // redimension the texture
+  tex
+    .resize_raw([width, height], 0, GenMipmaps::No, &texels)
+    .expect("texture resizing");
+}

--- a/luminance-gl/src/gl33/texture.rs
+++ b/luminance-gl/src/gl33/texture.rs
@@ -202,6 +202,17 @@ where
 
     Ok(texels)
   }
+
+  unsafe fn resize(
+    texture: &mut Self::TextureRepr,
+    size: D::Size,
+    mipmaps: usize,
+  ) -> Result<(), TextureError> {
+    let mipmaps = mipmaps + 1; // + 1 to prevent having 0 mipmaps
+    let mut state = texture.state.borrow_mut();
+    state.bind_texture(texture.target, texture.handle);
+    create_texture_storage::<D>(size, mipmaps, P::pixel_format())
+  }
 }
 
 pub(crate) fn opengl_target(d: Dim) -> GLenum {

--- a/luminance-webgl/src/webgl2/texture.rs
+++ b/luminance-webgl/src/webgl2/texture.rs
@@ -258,6 +258,16 @@ where
       )),
     }
   }
+
+  unsafe fn resize(
+    texture: &mut Self::TextureRepr,
+    size: D::Size,
+    mipmaps: usize,
+  ) -> Result<(), TextureError> {
+    let mipmaps = mipmaps + 1; // + 1 to prevent having 0 mipmaps
+    let mut state = texture.state.borrow_mut();
+    create_texture_storage::<D>(&mut state, size, mipmaps, P::pixel_format())
+  }
 }
 
 pub(crate) fn opengl_target(d: Dim) -> Option<u32> {

--- a/luminance/src/backend/texture.rs
+++ b/luminance/src/backend/texture.rs
@@ -75,4 +75,10 @@ where
   ) -> Result<Vec<P::RawEncoding>, TextureError>
   where
     P::RawEncoding: Copy + Default;
+
+  unsafe fn resize(
+    texture: &mut Self::TextureRepr,
+    size: D::Size,
+    mipmaps: usize,
+  ) -> Result<(), TextureError>;
 }

--- a/luminance/src/texture.rs
+++ b/luminance/src/texture.rs
@@ -613,6 +613,32 @@ where
     self.size
   }
 
+  /// Update the size of the texture.
+  pub fn resize(
+    &mut self,
+    size: D::Size,
+    mipmaps: usize,
+    gen_mipmaps: GenMipmaps,
+    texels: &[P::Encoding],
+  ) -> Result<(), TextureError> {
+    self.size = size;
+    unsafe { B::resize(&mut self.repr, size, mipmaps) }?;
+    self.upload(gen_mipmaps, texels)
+  }
+
+  /// Update the size of the texture with raw texels.
+  pub fn resize_raw(
+    &mut self,
+    size: D::Size,
+    mipmaps: usize,
+    gen_mipmaps: GenMipmaps,
+    texels: &[P::RawEncoding],
+  ) -> Result<(), TextureError> {
+    self.size = size;
+    unsafe { B::resize(&mut self.repr, size, mipmaps) }?;
+    self.upload_raw(gen_mipmaps, texels)
+  }
+
   /// Clear the texture with a single pixel value.
   ///
   /// This function will assign the input pixel value to all the pixels in the rectangle described


### PR DESCRIPTION
Both Encoding and RawEncoding are supported. The interface takes the
texels (and whether we should generate the mipmaps), and serves as a
proof of concept of the new interface to create textures.

Relates to #473.