### PR TITLE
Remove `CursorMode` from `luminance-glfw`.

### DIFF
--- a/luminance-glfw/CHANGELOG.md
+++ b/luminance-glfw/CHANGELOG.md
@@ -61,9 +61,11 @@ compatible with as many crates as possible. In that case, you want `cargo update
 
 # 0.16
 
-> Apr 25, 2021
+> `HEAD`
 
 - Support of `luminance-0.44`.
+- Lose support for `CursorMode`, which is now deprecated. If you were using it, you already have access to the
+  underlying `glfw` objects in the `GlfwSurface`, so you can tweak them as you see fit.
 
 # 0.15
 
@@ -75,7 +77,7 @@ compatible with as many crates as possible. In that case, you want `cargo update
   independently:
   - The event receiver from glfw. Use this with the GLFW API to retrieve / poll events.
   - A `GL33Context`, containing the GLFW window and the required internal luminance state, allowing you to perform
-      rendering operations.
+    rendering operations.
   This was needed to fix annoyances while iterating over events and wanting to make luminance calls — _deferring_ was
   required. This is no longer an issue with this fix and you can now issue luminance calls while iterating over events,
   yay, clap your hands if’re reading this!

--- a/luminance-glfw/src/lib.rs
+++ b/luminance-glfw/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(missing_docs)]
 
 use gl;
-use glfw::{self, Context, CursorMode as GlfwCursorMode, SwapInterval, Window, WindowMode};
+use glfw::{self, Context, SwapInterval, Window, WindowMode};
 use glfw::{InitError, WindowEvent};
 use luminance::context::GraphicsContext;
 use luminance::framebuffer::Framebuffer;
@@ -12,7 +12,7 @@ use luminance::framebuffer::FramebufferError;
 use luminance::texture::Dim2;
 pub use luminance_gl::gl33::StateQueryError;
 use luminance_gl::GL33;
-use luminance_windowing::{CursorMode, WindowDim, WindowOpt};
+use luminance_windowing::{WindowDim, WindowOpt};
 use std::error;
 use std::fmt;
 use std::os::raw::c_void;
@@ -131,12 +131,6 @@ impl GlfwSurface {
     };
 
     window.make_current();
-
-    match win_opt.cursor_mode() {
-      CursorMode::Visible => window.set_cursor_mode(GlfwCursorMode::Normal),
-      CursorMode::Invisible => window.set_cursor_mode(GlfwCursorMode::Hidden),
-      CursorMode::Disabled => window.set_cursor_mode(GlfwCursorMode::Disabled),
-    }
 
     window.set_all_polling(true);
     glfw.set_swap_interval(SwapInterval::Sync(1));

--- a/luminance-windowing/CHANGELOG.md
+++ b/luminance-windowing/CHANGELOG.md
@@ -42,9 +42,10 @@ compatible with as many crates as possible. In that case, you want `cargo update
 
 # 0.10
 
-> Apr 25, 2021
+> `HEAD`
 
 - Support of `luminance-0.44`.
+- Remove `CursorMode`. This is an implementation detail of each system crate.
 
 # 0.9.3
 

--- a/luminance-windowing/src/lib.rs
+++ b/luminance-windowing/src/lib.rs
@@ -28,19 +28,6 @@ pub enum WindowDim {
   },
 }
 
-/// Cursor mode.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CursorMode {
-  /// The cursor is always visible. It is up to the backend to decide what the visual representing
-  /// the cursor is.
-  Visible,
-  /// The cursor exists yet is not shown. It is up to the programmer / user to decide what the
-  /// visual representing the cursor is.
-  Invisible,
-  /// The cursor is disabled. It is not shown and should be considered non-active.
-  Disabled,
-}
-
 /// Different window options.
 ///
 /// Feel free to look at the different methods available to tweak the options. You may want to start
@@ -49,8 +36,6 @@ pub enum CursorMode {
 pub struct WindowOpt {
   /// Dimension of the window.
   pub dim: WindowDim,
-  /// Cursor mode.
-  pub cursor_mode: CursorMode,
   /// Number of samples for multisampling.
   ///
   /// `None` means no multisampling.
@@ -61,7 +46,6 @@ impl Default for WindowOpt {
   /// Defaults:
   ///
   /// - `dim`: set to WindowDim::Windowed { width: 960, 540 }`.
-  /// - `cursor_mode` set to `CursorMode::Visible`.
   /// - `num_samples` set to `None`.
   fn default() -> Self {
     WindowOpt {
@@ -69,7 +53,6 @@ impl Default for WindowOpt {
         width: 960,
         height: 540,
       },
-      cursor_mode: CursorMode::Visible,
       num_samples: None,
     }
   }
@@ -86,21 +69,6 @@ impl WindowOpt {
   #[inline]
   pub fn dim(&self) -> &WindowDim {
     &self.dim
-  }
-
-  /// Hide, unhide or disable the cursor.
-  #[inline]
-  pub fn set_cursor_mode(self, cursor_mode: CursorMode) -> Self {
-    WindowOpt {
-      cursor_mode,
-      ..self
-    }
-  }
-
-  /// Get the cursor mode.
-  #[inline]
-  pub fn cursor_mode(&self) -> &CursorMode {
-    &self.cursor_mode
   }
 
   /// Set the number of samples to use for multisampling.


### PR DESCRIPTION
This type is getting moved out as `luminance` is not about providing a
windowing solution. `luminance-glfw`, `luminance-glutin`,
`luminance-sdl2` and `luminance-web-sys` (so far) are just crates to
_ease_ creating the environment to work with those crates.

Relates to #342.