### PR TITLE
Use arrays instead of tuples for pixel encoding.

### DIFF
--- a/luminance-gl/src/gl33/texture.rs
+++ b/luminance-gl/src/gl33/texture.rs
@@ -184,11 +184,11 @@ where
     gl::GetTexLevelParameteriv(texture.target, 0, gl::TEXTURE_HEIGHT, &mut h);
 
     // set the packing alignment based on the number of bytes to skip
-    let skip_bytes = (pf.format.size() * w as usize) % 8;
+    let skip_bytes = (pf.format.bytes_len() * w as usize) % 8;
     set_pack_alignment(skip_bytes);
 
     // resize the vec to allocate enough space to host the returned texels
-    let mut texels = vec![Default::default(); (w * h) as usize * pf.canals_len()];
+    let mut texels = vec![Default::default(); (w * h) as usize * pf.channels_len()];
 
     gl::GetTexImage(
       texture.target,
@@ -568,7 +568,7 @@ where
   // number of bytes in the input texels argument
   let input_bytes = texels.len() * mem::size_of::<T>();
   let pf = P::pixel_format();
-  let pf_size = pf.format.size();
+  let pf_size = pf.format.bytes_len();
   let expected_bytes = D::count(size) * pf_size;
 
   if input_bytes < expected_bytes {

--- a/luminance-webgl/src/webgl2/texture.rs
+++ b/luminance-webgl/src/webgl2/texture.rs
@@ -200,7 +200,7 @@ where
     let h = D::height(size);
 
     // set the packing alignment based on the number of bytes to skip
-    let skip_bytes = (pf.format.size() * w as usize) % 8;
+    let skip_bytes = (pf.format.bytes_len() * w as usize) % 8;
     set_pack_alignment(&mut gfx_state, skip_bytes);
 
     // We need a workaround to get the texel data, because WebGL2 doesn’t support the glGetTexImage
@@ -209,7 +209,7 @@ where
     match gfx_state.create_or_get_readback_framebuffer() {
       Some(ref readback_fb) => {
         // Resize the vec to allocate enough space to host the returned texels.
-        let texels_nb = (w * h) as usize * pf.canals_len();
+        let texels_nb = (w * h) as usize * pf.channels_len();
         let mut texels = vec![Default::default(); texels_nb];
 
         // Attach the texture so that we can read from the framebuffer; careful here, since we are
@@ -566,7 +566,7 @@ where
   // number of bytes in the input texels argument
   let input_bytes = texels.len() * mem::size_of::<T>();
   let pf = P::pixel_format();
-  let pf_size = pf.format.size();
+  let pf_size = pf.format.bytes_len();
   let expected_bytes = D::count(size) * pf_size;
 
   if input_bytes < expected_bytes {

--- a/luminance/CHANGELOG.md
+++ b/luminance/CHANGELOG.md
@@ -130,15 +130,17 @@ compatible with as many crates as possible. In that case, you want `cargo update
 
 # 0.44
 
-> Apr 25, 2021
+> `HEAD`
 
+- This release marks the end of using SemVer ranges in the luminance ecosystem. Even though SemVer ranges are very
+  powerful and should be used widely in the Rust ecosystem, `cargo` doesn’t do the right thing with them and lots of
+  people are not used to them / often surprised by the behavior. Sorry.
 - Add texture resizing.
 - Cleanup texture creation. Methods such as `GraphicsContext::new_texture` and `GraphicsContext::new_texture_raw` now
   expects to pass the texels and mipmaps generation arguments. If you still want to reserve a texture without passing
   any texels, you can use `GraphicsContext::new_texture_no_texels`.
-- This release marks the end of using SemVer ranges in the luminance ecosystem. Even though SemVer ranges are very
-  powerful and should be used widely in the Rust ecosystem, `cargo` doesn’t do the right thing with them and lots of
-  people are not used to them / often surprised by the behavior. Sorry.
+- Use arrays instead of tuples for pixel types `Encoding`. A previous type such as `(u8, u8, u8)` now becomes `[u8; 3]`,
+  which has a stable and well-defined memory layout.
 
 # 0.43.2
 

--- a/luminance/src/pixel.rs
+++ b/luminance/src/pixel.rs
@@ -69,8 +69,8 @@ impl PixelFormat {
     !self.is_color_pixel()
   }
 
-  /// Return the number of canals.
-  pub fn canals_len(self) -> usize {
+  /// Return the number of channels.
+  pub fn channels_len(self) -> usize {
     match self.format {
       Format::R(_) => 1,
       Format::RG(_, _) => 2,
@@ -130,15 +130,15 @@ pub enum Format {
 
 impl Format {
   /// Size (in bytes) of a pixel that a format represents.
-  pub fn size(self) -> usize {
+  pub fn bytes_len(self) -> usize {
     let bits = match self {
-      Format::R(r) => r.bits(),
-      Format::RG(r, g) => r.bits() + g.bits(),
-      Format::RGB(r, g, b) => r.bits() + g.bits() + b.bits(),
-      Format::RGBA(r, g, b, a) => r.bits() + g.bits() + b.bits() + a.bits(),
-      Format::SRGB(r, g, b) => r.bits() + g.bits() + b.bits(),
-      Format::SRGBA(r, g, b, a) => r.bits() + g.bits() + b.bits() + a.bits(),
-      Format::Depth(d) => d.bits(),
+      Format::R(r) => r.bits_len(),
+      Format::RG(r, g) => r.bits_len() + g.bits_len(),
+      Format::RGB(r, g, b) => r.bits_len() + g.bits_len() + b.bits_len(),
+      Format::RGBA(r, g, b, a) => r.bits_len() + g.bits_len() + b.bits_len() + a.bits_len(),
+      Format::SRGB(r, g, b) => r.bits_len() + g.bits_len() + b.bits_len(),
+      Format::SRGBA(r, g, b, a) => r.bits_len() + g.bits_len() + b.bits_len() + a.bits_len(),
+      Format::Depth(d) => d.bits_len(),
     };
 
     bits / 8
@@ -162,7 +162,7 @@ pub enum Size {
 
 impl Size {
   /// Size (in bits).
-  pub fn bits(self) -> usize {
+  pub fn bits_len(self) -> usize {
     match self {
       Size::Eight => 8,
       Size::Ten => 10,
@@ -374,7 +374,7 @@ pub struct RG8I;
 
 impl_Pixel!(
   RG8I,
-  (i8, i8),
+  [i8; 2],
   i8,
   Integral,
   Format::RG(Size::Eight, Size::Eight)
@@ -388,7 +388,7 @@ pub struct NormRG8I;
 
 impl_Pixel!(
   NormRG8I,
-  (i8, i8),
+  [i8; 2],
   i8,
   NormIntegral,
   Format::RG(Size::Eight, Size::Eight)
@@ -402,7 +402,7 @@ pub struct RG8UI;
 
 impl_Pixel!(
   RG8UI,
-  (u8, u8),
+  [u8; 2],
   u8,
   Unsigned,
   Format::RG(Size::Eight, Size::Eight)
@@ -416,7 +416,7 @@ pub struct NormRG8UI;
 
 impl_Pixel!(
   NormRG8UI,
-  (u8, u8),
+  [u8; 2],
   u8,
   NormUnsigned,
   Format::RG(Size::Eight, Size::Eight)
@@ -430,7 +430,7 @@ pub struct RG16I;
 
 impl_Pixel!(
   RG16I,
-  (i16, i16),
+  [i16; 2],
   i16,
   Integral,
   Format::RG(Size::Sixteen, Size::Sixteen)
@@ -444,7 +444,7 @@ pub struct NormRG16I;
 
 impl_Pixel!(
   NormRG16I,
-  (i16, i16),
+  [i16; 2],
   i16,
   NormIntegral,
   Format::RG(Size::Sixteen, Size::Sixteen)
@@ -458,7 +458,7 @@ pub struct RG16UI;
 
 impl_Pixel!(
   RG16UI,
-  (u16, u16),
+  [u16; 2],
   u16,
   Unsigned,
   Format::RG(Size::Sixteen, Size::Sixteen)
@@ -472,7 +472,7 @@ pub struct NormRG16UI;
 
 impl_Pixel!(
   NormRG16UI,
-  (u16, u16),
+  [u16; 2],
   u16,
   NormUnsigned,
   Format::RG(Size::Sixteen, Size::Sixteen)
@@ -486,7 +486,7 @@ pub struct RG32I;
 
 impl_Pixel!(
   RG32I,
-  (i32, i32),
+  [i32; 2],
   i32,
   Integral,
   Format::RG(Size::ThirtyTwo, Size::ThirtyTwo)
@@ -500,7 +500,7 @@ pub struct NormRG32I;
 
 impl_Pixel!(
   NormRG32I,
-  (i32, i32),
+  [i32; 2],
   i32,
   NormIntegral,
   Format::RG(Size::ThirtyTwo, Size::ThirtyTwo)
@@ -514,7 +514,7 @@ pub struct RG32UI;
 
 impl_Pixel!(
   RG32UI,
-  (u32, u32),
+  [u32; 2],
   u32,
   Unsigned,
   Format::RG(Size::ThirtyTwo, Size::ThirtyTwo)
@@ -528,7 +528,7 @@ pub struct NormRG32UI;
 
 impl_Pixel!(
   NormRG32UI,
-  (u32, u32),
+  [u32; 2],
   u32,
   NormUnsigned,
   Format::RG(Size::ThirtyTwo, Size::ThirtyTwo)
@@ -542,7 +542,7 @@ pub struct RG32F;
 
 impl_Pixel!(
   RG32F,
-  (f32, f32),
+  [f32; 2],
   f32,
   Floating,
   Format::RG(Size::ThirtyTwo, Size::ThirtyTwo)
@@ -556,7 +556,7 @@ pub struct RGB8I;
 
 impl_Pixel!(
   RGB8I,
-  (i8, i8, i8),
+  [i8; 3],
   i8,
   Integral,
   Format::RGB(Size::Eight, Size::Eight, Size::Eight)
@@ -571,7 +571,7 @@ pub struct NormRGB8I;
 
 impl_Pixel!(
   NormRGB8I,
-  (i8, i8, i8),
+  [i8; 3],
   i8,
   NormIntegral,
   Format::RGB(Size::Eight, Size::Eight, Size::Eight)
@@ -585,7 +585,7 @@ pub struct RGB8UI;
 
 impl_Pixel!(
   RGB8UI,
-  (u8, u8, u8),
+  [u8; 3],
   u8,
   Unsigned,
   Format::RGB(Size::Eight, Size::Eight, Size::Eight)
@@ -600,7 +600,7 @@ pub struct NormRGB8UI;
 
 impl_Pixel!(
   NormRGB8UI,
-  (u8, u8, u8),
+  [u8; 3],
   u8,
   NormUnsigned,
   Format::RGB(Size::Eight, Size::Eight, Size::Eight)
@@ -614,7 +614,7 @@ pub struct RGB16I;
 
 impl_Pixel!(
   RGB16I,
-  (i16, i16, i16),
+  [i16; 3],
   i16,
   Integral,
   Format::RGB(Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -629,7 +629,7 @@ pub struct NormRGB16I;
 
 impl_Pixel!(
   NormRGB16I,
-  (i16, i16, i16),
+  [i16; 3],
   i16,
   NormIntegral,
   Format::RGB(Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -643,7 +643,7 @@ pub struct RGB16UI;
 
 impl_Pixel!(
   RGB16UI,
-  (u16, u16, u16),
+  [u16; 3],
   u16,
   Unsigned,
   Format::RGB(Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -658,7 +658,7 @@ pub struct NormRGB16UI;
 
 impl_Pixel!(
   NormRGB16UI,
-  (u16, u16, u16),
+  [u16; 3],
   u16,
   NormUnsigned,
   Format::RGB(Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -672,7 +672,7 @@ pub struct RGB32I;
 
 impl_Pixel!(
   RGB32I,
-  (i32, i32, i32),
+  [i32; 3],
   i32,
   Integral,
   Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo)
@@ -687,7 +687,7 @@ pub struct NormRGB32I;
 
 impl_Pixel!(
   NormRGB32I,
-  (i32, i32, i32),
+  [i32; 3],
   i32,
   NormIntegral,
   Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo)
@@ -701,7 +701,7 @@ pub struct RGB32UI;
 
 impl_Pixel!(
   RGB32UI,
-  (u32, u32, u32),
+  [u32; 3],
   u32,
   Unsigned,
   Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo)
@@ -716,7 +716,7 @@ pub struct NormRGB32UI;
 
 impl_Pixel!(
   NormRGB32UI,
-  (u32, u32, u32),
+  [u32; 3],
   u32,
   NormUnsigned,
   Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo)
@@ -730,7 +730,7 @@ pub struct RGB32F;
 
 impl_Pixel!(
   RGB32F,
-  (f32, f32, f32),
+  [f32; 3],
   f32,
   Floating,
   Format::RGB(Size::ThirtyTwo, Size::ThirtyTwo, Size::ThirtyTwo)
@@ -744,7 +744,7 @@ pub struct RGBA8I;
 
 impl_Pixel!(
   RGBA8I,
-  (i8, i8, i8, i8),
+  [i8; 4],
   i8,
   Integral,
   Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
@@ -759,7 +759,7 @@ pub struct NormRGBA8I;
 
 impl_Pixel!(
   NormRGBA8I,
-  (i8, i8, i8, i8),
+  [i8; 4],
   i8,
   NormIntegral,
   Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
@@ -773,7 +773,7 @@ pub struct RGBA8UI;
 
 impl_Pixel!(
   RGBA8UI,
-  (u8, u8, u8, u8),
+  [u8; 4],
   u8,
   Unsigned,
   Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
@@ -788,7 +788,7 @@ pub struct NormRGBA8UI;
 
 impl_Pixel!(
   NormRGBA8UI,
-  (u8, u8, u8, u8),
+  [u8; 4],
   u8,
   NormUnsigned,
   Format::RGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)
@@ -802,7 +802,7 @@ pub struct RGBA16I;
 
 impl_Pixel!(
   RGBA16I,
-  (i16, i16, i16, i16),
+  [i16; 4],
   i16,
   Integral,
   Format::RGBA(Size::Sixteen, Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -817,7 +817,7 @@ pub struct NormRGBA16I;
 
 impl_Pixel!(
   NormRGBA16I,
-  (i16, i16, i16, i16),
+  [i16; 4],
   i16,
   NormIntegral,
   Format::RGBA(Size::Sixteen, Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -831,7 +831,7 @@ pub struct RGBA16UI;
 
 impl_Pixel!(
   RGBA16UI,
-  (u16, u16, u16, u16),
+  [u16; 4],
   u16,
   Unsigned,
   Format::RGBA(Size::Sixteen, Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -846,7 +846,7 @@ pub struct NormRGBA16UI;
 
 impl_Pixel!(
   NormRGBA16UI,
-  (u16, u16, u16, u16),
+  [u16; 4],
   u16,
   NormUnsigned,
   Format::RGBA(Size::Sixteen, Size::Sixteen, Size::Sixteen, Size::Sixteen)
@@ -860,7 +860,7 @@ pub struct RGBA32I;
 
 impl_Pixel!(
   RGBA32I,
-  (i32, i32, i32, i32),
+  [i32; 4],
   i32,
   Integral,
   Format::RGBA(
@@ -880,7 +880,7 @@ pub struct NormRGBA32I;
 
 impl_Pixel!(
   NormRGBA32I,
-  (i32, i32, i32, i32),
+  [i32; 4],
   i32,
   NormIntegral,
   Format::RGBA(
@@ -899,7 +899,7 @@ pub struct RGBA32UI;
 
 impl_Pixel!(
   RGBA32UI,
-  (u32, u32, u32, u32),
+  [u32; 4],
   u32,
   Unsigned,
   Format::RGBA(
@@ -919,7 +919,7 @@ pub struct NormRGBA32UI;
 
 impl_Pixel!(
   NormRGBA32UI,
-  (u32, u32, u32, u32),
+  [u32; 4],
   u32,
   NormUnsigned,
   Format::RGBA(
@@ -938,7 +938,7 @@ pub struct RGBA32F;
 
 impl_Pixel!(
   RGBA32F,
-  (f32, f32, f32, f32),
+  [f32; 4],
   f32,
   Floating,
   Format::RGBA(
@@ -961,7 +961,7 @@ pub struct R11G11B10F;
 
 impl_Pixel!(
   R11G11B10F,
-  (f32, f32, f32, f32),
+  [f32; 4],
   f32,
   Floating,
   Format::RGB(Size::Eleven, Size::Eleven, Size::Ten)
@@ -975,7 +975,7 @@ pub struct SRGB8UI;
 
 impl_Pixel!(
   SRGB8UI,
-  (u8, u8, u8),
+  [u8; 3],
   u8,
   NormUnsigned,
   Format::SRGB(Size::Eight, Size::Eight, Size::Eight)
@@ -989,7 +989,7 @@ pub struct SRGBA8UI;
 
 impl_Pixel!(
   SRGBA8UI,
-  (u8, u8, u8, u8),
+  [u8; 4],
   u8,
   NormUnsigned,
   Format::SRGBA(Size::Eight, Size::Eight, Size::Eight, Size::Eight)


### PR DESCRIPTION
Relates to #477.