### PR TITLE
Feature/tess indices nb

### DIFF
--- a/luminance-examples/src/attributeless.rs
+++ b/luminance-examples/src/attributeless.rs
@@ -40,7 +40,7 @@ fn main() {
   // attributes / data); in our case, we’ll just render a triangle, which has three vertices
   let tess = context
     .new_tess()
-    .set_vertex_nb(3)
+    .set_render_vertex_nb(3)
     .set_mode(Mode::Triangle)
     .build()
     .unwrap();

--- a/luminance-examples/src/displacement-map.rs
+++ b/luminance-examples/src/displacement-map.rs
@@ -103,7 +103,7 @@ fn main() {
 
   let tess = context
     .new_tess()
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .set_mode(Mode::TriangleFan)
     .build()
     .unwrap();

--- a/luminance-examples/src/multiple-targets.rs
+++ b/luminance-examples/src/multiple-targets.rs
@@ -89,7 +89,7 @@ fn main() {
   // we’ll need an attributeless quad to fetch in full screen
   let quad = context
     .new_tess()
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .set_mode(Mode::TriangleFan)
     .build()
     .unwrap();

--- a/luminance-examples/src/offscreen.rs
+++ b/luminance-examples/src/offscreen.rs
@@ -92,7 +92,7 @@ fn main() {
   // we’ll need an attributeless quad to fetch in full screen
   let quad = context
     .new_tess()
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .set_mode(Mode::TriangleFan)
     .build()
     .unwrap();

--- a/luminance-examples/src/skybox.rs
+++ b/luminance-examples/src/skybox.rs
@@ -209,7 +209,7 @@ fn run() -> Result<(), AppError> {
   let fullscreen_quad = context
     .new_tess()
     .set_mode(Mode::TriangleStrip)
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .build()
     .map_err(|e| AppError::CannotBuildFullscreenQuad(Box::new(e)))?;
 

--- a/luminance-examples/src/texture.rs
+++ b/luminance-examples/src/texture.rs
@@ -68,7 +68,7 @@ fn run(texture_path: &Path) {
   // TriangleFan creates triangles by connecting the third (and next) vertex to the first one
   let tess = context
     .new_tess()
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .set_mode(Mode::TriangleFan)
     .build()
     .unwrap();

--- a/luminance-examples/src/texture_resize.rs
+++ b/luminance-examples/src/texture_resize.rs
@@ -73,7 +73,7 @@ fn run(texture_path: &Path, texture_path2: &Path) {
   // TriangleFan creates triangles by connecting the third (and next) vertex to the first one
   let tess = context
     .new_tess()
-    .set_vertex_nb(4)
+    .set_render_vertex_nb(4)
     .set_mode(Mode::TriangleFan)
     .build()
     .unwrap();

--- a/luminance-gl/src/gl33/buffer.rs
+++ b/luminance-gl/src/gl33/buffer.rs
@@ -79,6 +79,12 @@ impl<T> Buffer<T> {
   pub(crate) fn handle(&self) -> GLuint {
     self.gl_buf.handle
   }
+
+  /// Length of the buffer (number of elements).
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.buf.len()
+  }
 }
 
 unsafe impl<T> BufferBackend<T> for GL33

--- a/luminance-gl/src/gl33/tess.rs
+++ b/luminance-gl/src/gl33/tess.rs
@@ -41,8 +41,6 @@ where
 {
   vao: GLenum,
   mode: GLenum,
-  vert_nb: usize,
-  inst_nb: usize,
   patch_vert_nb: usize,
   index_state: Option<IndexedDrawState<I>>,
   state: Rc<RefCell<GLState>>,
@@ -147,8 +145,6 @@ where
     index_data: Vec<I>,
     instance_data: Option<W::Data>,
     mode: Mode,
-    vert_nb: usize,
-    inst_nb: usize,
     restart_index: Option<I>,
   ) -> Result<Self::TessRepr, TessError> {
     let mut vao: GLuint = 0;
@@ -176,8 +172,6 @@ where
     let raw = TessRaw {
       vao,
       mode,
-      vert_nb,
-      inst_nb,
       patch_vert_nb,
       index_state,
       state,
@@ -192,11 +186,28 @@ where
   }
 
   unsafe fn tess_vertices_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.vert_nb
+    tess
+      .vertex_buffer
+      .as_ref()
+      .map(|vb| vb.buf.len())
+      .unwrap_or(0)
+  }
+
+  unsafe fn tess_indices_nb(tess: &Self::TessRepr) -> usize {
+    tess
+      .raw
+      .index_state
+      .as_ref()
+      .map(|ids| ids.buffer.len())
+      .unwrap_or(0)
   }
 
   unsafe fn tess_instances_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.inst_nb
+    tess
+      .instance_buffer
+      .as_ref()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn render(
@@ -314,8 +325,6 @@ where
     index_data: Vec<I>,
     instance_data: Option<W::Data>,
     mode: Mode,
-    vert_nb: usize,
-    inst_nb: usize,
     restart_index: Option<I>,
   ) -> Result<Self::TessRepr, TessError> {
     let mut vao: GLuint = 0;
@@ -343,8 +352,6 @@ where
     let raw = TessRaw {
       vao,
       mode,
-      vert_nb,
-      inst_nb,
       patch_vert_nb,
       index_state,
       state,
@@ -360,11 +367,28 @@ where
   }
 
   unsafe fn tess_vertices_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.vert_nb
+    tess
+      .vertex_buffers
+      .first()
+      .map(|vb| vb.buf.len())
+      .unwrap_or(0)
+  }
+
+  unsafe fn tess_indices_nb(tess: &Self::TessRepr) -> usize {
+    tess
+      .raw
+      .index_state
+      .as_ref()
+      .map(|ids| ids.buffer.len())
+      .unwrap_or(0)
   }
 
   unsafe fn tess_instances_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.inst_nb
+    tess
+      .instance_buffers
+      .first()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn render(

--- a/luminance-webgl/src/webgl2/tess.rs
+++ b/luminance-webgl/src/webgl2/tess.rs
@@ -29,8 +29,6 @@ where
 {
   vao: WebGlVertexArrayObject,
   mode: u32,
-  vert_nb: usize,
-  inst_nb: usize,
   // A small note: WebGL2 doesn’t support custom primitive restart index; it assumes the maximum
   // value of I as being that restart index.
   index_buffer: Option<Buffer<I>>,
@@ -131,8 +129,6 @@ where
     index_data: Vec<I>,
     instance_data: Option<W::Data>,
     mode: Mode,
-    vert_nb: usize,
-    inst_nb: usize,
     _: Option<I>,
   ) -> Result<Self::TessRepr, TessError> {
     let vao = self
@@ -157,8 +153,6 @@ where
     let raw = TessRaw {
       vao,
       mode,
-      vert_nb,
-      inst_nb,
       index_buffer,
       state,
     };
@@ -171,11 +165,28 @@ where
   }
 
   unsafe fn tess_vertices_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.vert_nb
+    tess
+      .vertex_buffer
+      .as_ref()
+      .map(|vb| vb.buf.len())
+      .unwrap_or(0)
+  }
+
+  unsafe fn tess_indices_nb(tess: &Self::TessRepr) -> usize {
+    tess
+      .raw
+      .index_buffer
+      .as_ref()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn tess_instances_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.inst_nb
+    tess
+      .instance_buffer
+      .as_ref()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn render(
@@ -293,8 +304,6 @@ where
     index_data: Vec<I>,
     instance_data: Option<W::Data>,
     mode: Mode,
-    vert_nb: usize,
-    inst_nb: usize,
     _: Option<I>,
   ) -> Result<Self::TessRepr, TessError> {
     let vao = self
@@ -319,8 +328,6 @@ where
     let raw = TessRaw {
       vao,
       mode,
-      vert_nb,
-      inst_nb,
       index_buffer,
       state,
     };
@@ -334,11 +341,28 @@ where
   }
 
   unsafe fn tess_vertices_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.vert_nb
+    tess
+      .vertex_buffers
+      .first()
+      .map(|vb| vb.buf.len())
+      .unwrap_or(0)
+  }
+
+  unsafe fn tess_indices_nb(tess: &Self::TessRepr) -> usize {
+    tess
+      .raw
+      .index_buffer
+      .as_ref()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn tess_instances_nb(tess: &Self::TessRepr) -> usize {
-    tess.raw.inst_nb
+    tess
+      .instance_buffers
+      .first()
+      .map(|ib| ib.buf.len())
+      .unwrap_or(0)
   }
 
   unsafe fn render(

--- a/luminance/src/backend/tess.rs
+++ b/luminance/src/backend/tess.rs
@@ -28,6 +28,8 @@ where
 
   unsafe fn tess_vertices_nb(tess: &Self::TessRepr) -> usize;
 
+  unsafe fn tess_indices_nb(tess: &Self::TessRepr) -> usize;
+
   unsafe fn tess_instances_nb(tess: &Self::TessRepr) -> usize;
 
   unsafe fn render(

--- a/luminance/src/backend/tess.rs
+++ b/luminance/src/backend/tess.rs
@@ -21,8 +21,6 @@ where
     index_data: Vec<I>,
     instance_data: Option<W::Data>,
     mode: Mode,
-    vert_nb: usize,
-    inst_nb: usize,
     restart_index: Option<I>,
   ) -> Result<Self::TessRepr, TessError>;
 

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -925,6 +925,11 @@ where
     unsafe { B::tess_vertices_nb(&self.repr) }
   }
 
+  /// Get the number of vertex indices.
+  pub fn idx_nb(&self) -> usize {
+    unsafe { B::tess_indices_nb(&self.repr) }
+  }
+
   /// Get the number of instances.
   pub fn inst_nb(&self) -> usize {
     unsafe { B::tess_instances_nb(&self.repr) }


### PR DESCRIPTION
This allows to query the number of elements in the actual storage used by the backends but also query the number of default vertices / vertex instances to render. It also removes the burden of forwarding those counts in the backend implementations.