### PR TITLE
Add premises of the Query API.

### DIFF
--- a/luminance-examples/Cargo.toml
+++ b/luminance-examples/Cargo.toml
@@ -79,6 +79,10 @@ path = "src/interactive-triangle.rs"
 name = "skybox"
 path = "src/skybox.rs"
 
+[[bin]]
+name = "query-info"
+path = "src/query-info.rs"
+
 [dependencies]
 cgmath = "0.18"
 env_logger = "0.8.1"

--- a/luminance-examples/src/query-info.rs
+++ b/luminance-examples/src/query-info.rs
@@ -26,4 +26,8 @@ fn main() {
     "Backend shading language version: {:?}",
     q.backend_shading_lang_version()
   );
+  println!(
+    "Maximum number of elements in a texture array: {:?}",
+    q.max_texture_array_elements()
+  )
 }

--- a/luminance-examples/src/query-info.rs
+++ b/luminance-examples/src/query-info.rs
@@ -1,0 +1,29 @@
+//! This program demonstrates the Query API, allowing to get information about the GPU and the backend.
+//!
+//! https://docs.rs/luminance
+
+use luminance::context::GraphicsContext as _;
+use luminance_glfw::GlfwSurface;
+use luminance_windowing::{WindowDim, WindowOpt};
+
+fn main() {
+  let dim = WindowDim::Windowed {
+    width: 960,
+    height: 540,
+  };
+  let surface = GlfwSurface::new_gl33(
+    "Hello, world; from OpenGL 3.3!",
+    WindowOpt::default().set_dim(dim),
+  )
+  .expect("GLFW surface creation");
+  let mut context = surface.context;
+  let q = context.query();
+
+  println!("Backend author: {:?}", q.backend_author());
+  println!("Backend name: {:?}", q.backend_name());
+  println!("Backend version: {:?}", q.backend_version());
+  println!(
+    "Backend shading language version: {:?}",
+    q.backend_shading_lang_version()
+  );
+}

--- a/luminance-front/src/lib.rs
+++ b/luminance-front/src/lib.rs
@@ -63,6 +63,7 @@ pub mod buffer;
 pub mod context;
 pub mod framebuffer;
 pub mod pipeline;
+pub mod query;
 pub mod render_gate;
 pub mod shader;
 pub mod shading_gate;

--- a/luminance-front/src/query.rs
+++ b/luminance-front/src/query.rs
@@ -1,0 +1,3 @@
+use crate::Backend;
+
+pub type Query<'a> = luminance::query::Query<'a, Backend>;

--- a/luminance-gl/src/gl33.rs
+++ b/luminance-gl/src/gl33.rs
@@ -5,6 +5,7 @@ mod depth_test;
 mod framebuffer;
 mod pipeline;
 mod pixel;
+mod query;
 mod shader;
 mod state;
 mod tess;

--- a/luminance-gl/src/gl33/query.rs
+++ b/luminance-gl/src/gl33/query.rs
@@ -1,0 +1,26 @@
+//! Query API implementation for OpenGL 3.3.
+
+use crate::GL33;
+use luminance::backend::query::{Query as QueryBackend, QueryError};
+
+unsafe impl QueryBackend for GL33 {
+  fn backend_author(&self) -> Result<String, QueryError> {
+    let name = self.state.borrow_mut().get_vendor_name();
+    Ok(name)
+  }
+
+  fn backend_name(&self) -> Result<String, QueryError> {
+    let name = self.state.borrow_mut().get_renderer_name();
+    Ok(name)
+  }
+
+  fn backend_version(&self) -> Result<String, QueryError> {
+    let name = self.state.borrow_mut().get_gl_version();
+    Ok(name)
+  }
+
+  fn backend_shading_lang_version(&self) -> Result<String, QueryError> {
+    let name = self.state.borrow_mut().get_glsl_version();
+    Ok(name)
+  }
+}

--- a/luminance-gl/src/gl33/query.rs
+++ b/luminance-gl/src/gl33/query.rs
@@ -23,4 +23,9 @@ unsafe impl QueryBackend for GL33 {
     let name = self.state.borrow_mut().get_glsl_version();
     Ok(name)
   }
+
+  fn max_texture_array_elements(&self) -> Result<usize, QueryError> {
+    let max = self.state.borrow_mut().get_max_texture_array_elements();
+    Ok(max)
+  }
 }

--- a/luminance-webgl/src/webgl2.rs
+++ b/luminance-webgl/src/webgl2.rs
@@ -5,6 +5,7 @@ pub mod buffer;
 pub mod framebuffer;
 pub mod pipeline;
 pub mod pixel;
+pub mod query;
 pub mod shader;
 pub mod state;
 pub mod tess;

--- a/luminance-webgl/src/webgl2/query.rs
+++ b/luminance-webgl/src/webgl2/query.rs
@@ -35,4 +35,12 @@ unsafe impl QueryBackend for WebGL2 {
       .get_glsl_version()
       .ok_or_else(|| QueryError::NoBackendShadingLanguageVersion)
   }
+
+  fn max_texture_array_elements(&self) -> Result<usize, QueryError> {
+    self
+      .state
+      .borrow_mut()
+      .get_max_texture_array_elements()
+      .ok_or_else(|| QueryError::NoMaxTextureArrayElements)
+  }
 }

--- a/luminance-webgl/src/webgl2/query.rs
+++ b/luminance-webgl/src/webgl2/query.rs
@@ -1,0 +1,38 @@
+//! Query API implementation.
+
+use crate::WebGL2;
+use luminance::backend::query::{Query as QueryBackend, QueryError};
+
+unsafe impl QueryBackend for WebGL2 {
+  fn backend_author(&self) -> Result<String, QueryError> {
+    self
+      .state
+      .borrow_mut()
+      .get_vendor_name()
+      .ok_or_else(|| QueryError::NoBackendAuthor)
+  }
+
+  fn backend_name(&self) -> Result<String, QueryError> {
+    self
+      .state
+      .borrow_mut()
+      .get_renderer_name()
+      .ok_or_else(|| QueryError::NoBackendName)
+  }
+
+  fn backend_version(&self) -> Result<String, QueryError> {
+    self
+      .state
+      .borrow_mut()
+      .get_webgl_version()
+      .ok_or_else(|| QueryError::NoBackendVersion)
+  }
+
+  fn backend_shading_lang_version(&self) -> Result<String, QueryError> {
+    self
+      .state
+      .borrow_mut()
+      .get_glsl_version()
+      .ok_or_else(|| QueryError::NoBackendShadingLanguageVersion)
+  }
+}

--- a/luminance-webgl/src/webgl2/state.rs
+++ b/luminance-webgl/src/webgl2/state.rs
@@ -122,6 +122,9 @@ pub struct WebGL2State {
 
   // GLSL version; cached when asked the first time and then re-used
   glsl_version: Option<String>,
+
+  /// Maximum number of elements a texture array can hold.
+  max_texture_array_elements: Option<usize>,
 }
 
 impl WebGL2State {
@@ -169,6 +172,7 @@ impl WebGL2State {
     let renderer_name = None;
     let gl_version = None;
     let glsl_version = None;
+    let max_texture_array_elements = None;
 
     Ok(WebGL2State {
       _phantom: PhantomData,
@@ -202,6 +206,7 @@ impl WebGL2State {
       renderer_name,
       webgl_version: gl_version,
       glsl_version,
+      max_texture_array_elements,
     })
   }
 
@@ -629,6 +634,19 @@ impl WebGL2State {
         .and_then(|p| p.as_string())?;
       self.glsl_version = Some(version);
       self.glsl_version.clone()
+    })
+  }
+
+  /// Get the number of maximum elements an array texture can hold.
+  ///
+  /// Cache the number on the first call and then re-use it for later calls.
+  pub fn get_max_texture_array_elements(&mut self) -> Option<usize> {
+    self.max_texture_array_elements.or_else(|| {
+      let max = self
+        .ctx
+        .get_webgl_param(WebGl2RenderingContext::MAX_ARRAY_TEXTURE_LAYERS);
+      self.max_texture_array_elements = max.clone();
+      max
     })
   }
 }

--- a/luminance-webgl/src/webgl2/state.rs
+++ b/luminance-webgl/src/webgl2/state.rs
@@ -1108,15 +1108,23 @@ trait GetWebGLParam<T> {
   fn get_webgl_param(&mut self, param: u32) -> Option<T>;
 }
 
-impl GetWebGLParam<u32> for WebGl2RenderingContext {
-  fn get_webgl_param(&mut self, param: u32) -> Option<u32> {
-    self
-      .get_parameter(param)
-      .ok()
-      .and_then(|x| x.as_f64())
-      .map(|x| x as u32)
+macro_rules! impl_GetWebGLParam_integer {
+  ($($int_ty:ty),*) => {
+    $(
+      impl GetWebGLParam<$int_ty> for WebGl2RenderingContext {
+        fn get_webgl_param(&mut self, param: u32) -> Option<$int_ty> {
+          self
+            .get_parameter(param)
+            .ok()
+            .and_then(|x| x.as_f64())
+            .map(|x| x as $int_ty)
+        }
+      }
+    )*
   }
 }
+
+impl_GetWebGLParam_integer!(u32, usize);
 
 impl GetWebGLParam<bool> for WebGl2RenderingContext {
   fn get_webgl_param(&mut self, param: u32) -> Option<bool> {

--- a/luminance-webgl/src/webgl2/state.rs
+++ b/luminance-webgl/src/webgl2/state.rs
@@ -107,8 +107,21 @@ pub struct WebGL2State {
 
   // vertex array
   bound_vertex_array: Option<WebGlVertexArrayObject>,
+
   // shader program
   current_program: Option<WebGlProgram>,
+
+  // vendor name; cached when asked the first time and then re-used
+  vendor_name: Option<String>,
+
+  // renderer name; cached when asked the first time and then re-used
+  renderer_name: Option<String>,
+
+  // WebGL version; cached when asked the first time and then re-used
+  webgl_version: Option<String>,
+
+  // GLSL version; cached when asked the first time and then re-used
+  glsl_version: Option<String>,
 }
 
 impl WebGL2State {
@@ -152,6 +165,11 @@ impl WebGL2State {
     let bound_vertex_array = None;
     let current_program = None;
 
+    let vendor_name = None;
+    let renderer_name = None;
+    let gl_version = None;
+    let glsl_version = None;
+
     Ok(WebGL2State {
       _phantom: PhantomData,
       ctx,
@@ -180,6 +198,10 @@ impl WebGL2State {
       readback_framebuffer,
       bound_vertex_array,
       current_program,
+      vendor_name,
+      renderer_name,
+      webgl_version: gl_version,
+      glsl_version,
     })
   }
 
@@ -560,6 +582,54 @@ impl WebGL2State {
         .scissor(x as i32, y as i32, width as i32, height as i32);
       self.scissor_region = *region;
     }
+  }
+
+  pub(crate) fn get_vendor_name(&mut self) -> Option<String> {
+    self.vendor_name.as_ref().cloned().or_else(|| {
+      let name = self
+        .ctx
+        .get_parameter(WebGl2RenderingContext::VENDOR)
+        .ok()
+        .and_then(|p| p.as_string())?;
+      self.vendor_name = Some(name);
+      self.vendor_name.clone()
+    })
+  }
+
+  pub(crate) fn get_renderer_name(&mut self) -> Option<String> {
+    self.renderer_name.as_ref().cloned().or_else(|| {
+      let name = self
+        .ctx
+        .get_parameter(WebGl2RenderingContext::RENDERER)
+        .ok()
+        .and_then(|p| p.as_string())?;
+      self.renderer_name = Some(name);
+      self.renderer_name.clone()
+    })
+  }
+
+  pub(crate) fn get_webgl_version(&mut self) -> Option<String> {
+    self.webgl_version.as_ref().cloned().or_else(|| {
+      let version = self
+        .ctx
+        .get_parameter(WebGl2RenderingContext::VERSION)
+        .ok()
+        .and_then(|p| p.as_string())?;
+      self.webgl_version = Some(version);
+      self.webgl_version.clone()
+    })
+  }
+
+  pub(crate) fn get_glsl_version(&mut self) -> Option<String> {
+    self.glsl_version.as_ref().cloned().or_else(|| {
+      let version = self
+        .ctx
+        .get_parameter(WebGl2RenderingContext::SHADING_LANGUAGE_VERSION)
+        .ok()
+        .and_then(|p| p.as_string())?;
+      self.glsl_version = Some(version);
+      self.glsl_version.clone()
+    })
   }
 }
 

--- a/luminance/src/backend.rs
+++ b/luminance/src/backend.rs
@@ -73,6 +73,7 @@ pub mod color_slot;
 pub mod depth_slot;
 pub mod framebuffer;
 pub mod pipeline;
+pub mod query;
 pub mod render_gate;
 pub mod shader;
 pub mod shading_gate;

--- a/luminance/src/backend/query.rs
+++ b/luminance/src/backend/query.rs
@@ -1,0 +1,51 @@
+//! Query backend interface.
+//!
+//! This interface provides various means to query some metrics and data from the GPU, such as the maximum number of
+//! active texture units, memory sizes, etc.
+
+use std::fmt;
+
+/// Query error.
+#[derive(Debug)]
+pub enum QueryError {
+  /// No backend author information available.
+  NoBackendAuthor,
+
+  /// No backend name information available.
+  NoBackendName,
+
+  /// No backend version information available.
+  NoBackendVersion,
+
+  /// No backend shading language version information available.
+  NoBackendShadingLanguageVersion,
+}
+
+impl fmt::Display for QueryError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      QueryError::NoBackendAuthor => f.write_str("no backend author available"),
+      QueryError::NoBackendName => f.write_str("no backend name available"),
+      QueryError::NoBackendVersion => f.write_str("no backend version available"),
+      QueryError::NoBackendShadingLanguageVersion => {
+        f.write_str("no backend shading language version available")
+      }
+    }
+  }
+}
+
+/// Backends that support querying.
+pub unsafe trait Query {
+  /// The implementation author, most of the time referred to as “vendor” or “compagny” responsible for the driver the
+  /// implementation uses.
+  fn backend_author(&self) -> Result<String, QueryError>;
+
+  /// The backend name.
+  fn backend_name(&self) -> Result<String, QueryError>;
+
+  /// The backend version.
+  fn backend_version(&self) -> Result<String, QueryError>;
+
+  /// The shading language version.
+  fn backend_shading_lang_version(&self) -> Result<String, QueryError>;
+}

--- a/luminance/src/backend/query.rs
+++ b/luminance/src/backend/query.rs
@@ -19,6 +19,9 @@ pub enum QueryError {
 
   /// No backend shading language version information available.
   NoBackendShadingLanguageVersion,
+
+  /// No maximum number of elements for texture arrays information available.
+  NoMaxTextureArrayElements,
 }
 
 impl fmt::Display for QueryError {
@@ -29,6 +32,9 @@ impl fmt::Display for QueryError {
       QueryError::NoBackendVersion => f.write_str("no backend version available"),
       QueryError::NoBackendShadingLanguageVersion => {
         f.write_str("no backend shading language version available")
+      }
+      QueryError::NoMaxTextureArrayElements => {
+        f.write_str("no maximum number of elements for texture arrays available")
       }
     }
   }
@@ -48,4 +54,7 @@ pub unsafe trait Query {
 
   /// The shading language version.
   fn backend_shading_lang_version(&self) -> Result<String, QueryError>;
+
+  /// The maximum number of elements a texture array can hold.
+  fn max_texture_array_elements(&self) -> Result<usize, QueryError>;
 }

--- a/luminance/src/context.rs
+++ b/luminance/src/context.rs
@@ -43,21 +43,20 @@
 //! let buffer = context.new_buffer_from_slice(slice).unwrap();
 //! ```
 
-use crate::backend::color_slot::ColorSlot;
-use crate::backend::depth_slot::DepthSlot;
-use crate::backend::framebuffer::Framebuffer as FramebufferBackend;
-use crate::backend::shader::Shader;
-use crate::backend::tess::Tess as TessBackend;
-use crate::backend::texture::Texture as TextureBackend;
+use crate::backend::{
+  buffer::Buffer as BufferBackend, color_slot::ColorSlot, depth_slot::DepthSlot,
+  framebuffer::Framebuffer as FramebufferBackend, query::Query as QueryBackend, shader::Shader,
+  tess::Tess as TessBackend, texture::Texture as TextureBackend,
+};
 use crate::buffer::{Buffer, BufferError};
 use crate::framebuffer::{Framebuffer, FramebufferError};
 use crate::pipeline::PipelineGate;
 use crate::pixel::Pixel;
+use crate::query::Query;
 use crate::shader::{ProgramBuilder, Stage, StageError, StageType};
 use crate::tess::{Deinterleaved, Interleaved, TessBuilder, TessVertexData};
-use crate::texture::{Dimensionable, Sampler, Texture, TextureError};
+use crate::texture::{Dimensionable, GenMipmaps, Sampler, Texture, TextureError};
 use crate::vertex::Semantics;
-use crate::{backend::buffer::Buffer as BufferBackend, texture::GenMipmaps};
 
 /// Class of graphics context.
 ///
@@ -70,6 +69,14 @@ pub unsafe trait GraphicsContext: Sized {
 
   /// Access the underlying backend.
   fn backend(&mut self) -> &mut Self::Backend;
+
+  /// Access the query API.
+  fn query(&mut self) -> Query<Self::Backend>
+  where
+    Self::Backend: QueryBackend,
+  {
+    Query::new(self)
+  }
 
   /// Create a new pipeline gate
   fn new_pipeline_gate(&mut self) -> PipelineGate<Self::Backend> {

--- a/luminance/src/lib.rs
+++ b/luminance/src/lib.rs
@@ -193,6 +193,7 @@ pub mod face_culling;
 pub mod framebuffer;
 pub mod pipeline;
 pub mod pixel;
+pub mod query;
 pub mod render_gate;
 pub mod render_state;
 pub mod scissor;

--- a/luminance/src/query.rs
+++ b/luminance/src/query.rs
@@ -1,0 +1,51 @@
+//! GPU queries.
+//!
+//! GPU queries allow to get information about the backend and the GPU in a straight-forward way.
+
+use crate::{
+  backend::query::{Query as QueryBackend, QueryError},
+  context::GraphicsContext,
+};
+
+/// Query object.
+///
+/// Such an object allows to query various parts of the backend and GPU.
+#[derive(Debug)]
+pub struct Query<'a, B>
+where
+  B: ?Sized,
+{
+  backend: &'a B,
+}
+
+impl<'a, B> Query<'a, B>
+where
+  B: ?Sized + QueryBackend,
+{
+  /// Create a new [`Query`] for a given context.
+  pub fn new(ctxt: &'a mut impl GraphicsContext<Backend = B>) -> Self {
+    let backend = ctxt.backend();
+    Self { backend }
+  }
+
+  /// The implementation author, most of the time referred to as “vendor” or “compagny” responsible for the driver the
+  /// implementation uses.
+  pub fn backend_author(&self) -> Result<String, QueryError> {
+    self.backend.backend_author()
+  }
+
+  /// The backend name.
+  pub fn backend_name(&self) -> Result<String, QueryError> {
+    self.backend.backend_name()
+  }
+
+  /// The backend version.
+  pub fn backend_version(&self) -> Result<String, QueryError> {
+    self.backend.backend_version()
+  }
+
+  /// The shading language version.
+  pub fn backend_shading_lang_version(&self) -> Result<String, QueryError> {
+    self.backend.backend_shading_lang_version()
+  }
+}

--- a/luminance/src/query.rs
+++ b/luminance/src/query.rs
@@ -48,4 +48,9 @@ where
   pub fn backend_shading_lang_version(&self) -> Result<String, QueryError> {
     self.backend.backend_shading_lang_version()
   }
+
+  /// Maximum number of elements a texture array can hold.
+  pub fn max_texture_array_elements(&self) -> Result<usize, QueryError> {
+    self.backend.max_texture_array_elements()
+  }
 }


### PR DESCRIPTION
This commit introduces the very beginning of the Query API, that will be
used to implement various queries on the backend to provide versions,
names and capabilities of the GPU / hardware.

This commit introduces the main API along with:

- The backend “author” (vendor, company, etc.).
- The backend name.
- The backend version.
- The backend shading language version.

This commit holds both the implementations for the OpenGL 3.3 and WebGL2
backends.

Relates to #492.