### PR TITLE
Fix buffer target corruption in WebGL2 backend.

### DIFF
--- a/examples/common/src/funtest_483_indices_mut_corruption.rs
+++ b/examples/common/src/funtest_483_indices_mut_corruption.rs
@@ -1,0 +1,45 @@
+use crate::{shared::Vertex, Example, InputAction, LoopFeedback, PlatformServices};
+use luminance_front::{context::GraphicsContext, framebuffer::Framebuffer, texture::Dim2, Backend};
+use std::ops::Deref as _;
+
+pub struct LocalExample;
+
+impl Example for LocalExample {
+  fn bootstrap(
+    _: &mut impl PlatformServices,
+    context: &mut impl GraphicsContext<Backend = Backend>,
+  ) -> Self {
+    let vertices = [
+      Vertex::new([1., 2.].into(), [1., 1., 1.].into()),
+      Vertex::new([-1., 2.].into(), [1., 0., 1.].into()),
+      Vertex::new([1., -2.].into(), [1., 1., 0.].into()),
+    ];
+    let mut tess = context
+      .new_tess()
+      .set_vertices(&vertices[..])
+      .set_indices([0u8, 1, 2])
+      .set_mode(luminance_front::tess::Mode::Point)
+      .build()
+      .expect("tessellation");
+
+    {
+      let mut slice = tess.indices_mut().expect("sliced indices");
+      log::info!("slice before mutation is: {:?}", slice.deref());
+
+      slice[1] = 2;
+      log::info!("slice after mutation is:  {:?}", slice.deref());
+    }
+
+    LocalExample
+  }
+
+  fn render_frame(
+    self,
+    _: f32,
+    _: Framebuffer<Dim2, (), ()>,
+    _: impl Iterator<Item = InputAction>,
+    _: &mut impl GraphicsContext<Backend = Backend>,
+  ) -> LoopFeedback<Self> {
+    LoopFeedback::Exit
+  }
+}

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -49,6 +49,8 @@ pub mod vertex_instancing;
 #[cfg(feature = "funtest")]
 pub mod funtest_360_manually_drop_framebuffer;
 #[cfg(feature = "funtest")]
+pub mod funtest_483_indices_mut_corruption;
+#[cfg(feature = "funtest")]
 pub mod funtest_flatten_slice;
 #[cfg(all(feature = "funtest", feature = "funtest-gl33-f64-uniform"))]
 pub mod funtest_gl33_f64_uniform;

--- a/examples/desktop/src/main.rs
+++ b/examples/desktop/src/main.rs
@@ -210,6 +210,7 @@ examples! {
   "funtest-360-manually-drop-framebuffer", funtest_360_manually_drop_framebuffer,
   "funtest-flatten-slice", funtest_flatten_slice,
   "funtest-pixel-array-encoding", funtest_pixel_array_encoding,
+  "funtest-483-indices-mut-corruption", funtest_483_indices_mut_corruption,
 }
 
 fn main() {

--- a/examples/web/src/lib.rs
+++ b/examples/web/src/lib.rs
@@ -282,6 +282,7 @@ examples! {
   "funtest-360-manually-drop-framebuffer", funtest_360_manually_drop_framebuffer,
   "funtest-flatten-slice", funtest_flatten_slice,
   "funtest-pixel-array-encoding", funtest_pixel_array_encoding,
+  "funtest-483-indices-mut-corruption", funtest_483_indices_mut_corruption,
 }
 
 #[wasm_bindgen]

--- a/luminance-webgl/CHANGELOG.md
+++ b/luminance-webgl/CHANGELOG.md
@@ -11,6 +11,8 @@ compatible with as many crates as possible. In that case, you want `cargo update
 
 <!-- vim-markdown-toc GFM -->
 
+* [0.4 + 1](#04--1)
+  * [Patch changes](#patch-changes)
 * [0.4](#04)
 * [0.3.2](#032)
 * [0.3.1](#031)
@@ -24,6 +26,15 @@ compatible with as many crates as possible. In that case, you want `cargo update
 * [0.1](#01)
 
 <!-- vim-markdown-toc -->
+
+# 0.4 + 1
+
+> ?
+
+## Patch changes
+
+- Fix buffer kind not correctly being used (i.e. mixing vertex and index buffers is not possible, for instance). This
+  fix was the premise of the full fix, as a redesign of luminance’s buffer interface was needed to fully fix the problem.
 
 # 0.4
 


### PR DESCRIPTION
In the OpenGL 3.3 backend, there is an optimization that allows a
buffer object to be created and bound to a given target (for instance
`ARRAY_BUFFER`) and allows to rebind the buffer later to another
target (for instance `ELEMENT_ARRAY_BUFFER`). That optimization is handy
because it allows to dissociate data storage from data representation,
allowing to send a bunch of bytes and then using the target as source of
representation.

Well, turns out that optimization doesn’t work in WebGL2, so this commit
implements a way to keep track of what a buffer was created as and then
re-use that information every time we need to bind the buffer. That
should fix #483 (and probably other bugs no one has encountered yet).

Some integration tests are needed to ensure the fix does what it should.