### PR TITLE
Raise an error when a Vertex has fields of the same type.

### DIFF
--- a/luminance-derive/src/lib.rs
+++ b/luminance-derive/src/lib.rs
@@ -67,6 +67,7 @@ use syn::{self, parse_macro_input, Data, DeriveInput};
 ///   - Its fields must have a type that implements [`HasSemantics`] as well. This trait is just a
 ///     type family that associates a single constant (i.e. the semantics) that the vertex attribute
 ///     uses.
+///   - Each field's type must be different.
 ///
 /// Once all those requirements are met, you can derive [`Vertex`] pretty easily.
 ///


### PR DESCRIPTION
Hi! I was messing around with this crate and didn't realize that fields of a struct deriving `Vertex` needed to have different types (ex `struct Vertex { pos: VertexPosition, tex_coords: VertexPosition }` vs `struct Vertex { pos: VertexPosition, tex_coords: TextureCoords }`), so I was confused by a few compiler errors that came up as a result. This clarifies those errors when processing the macro instead of leaving it up to rustc.

I'm new to contributing to OS projects/graphics programming, so I'm not sure if I'm missing anything. Thanks!!