### PR TITLE
[luminance] Fix Tess::instances{,_mut}.

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -13,6 +13,8 @@
   This change shouldn’t create any issue if your code is sound but if you were doing something like dropping a `Tess`
   while still maintaining a slice, or randomly dropping `Tess` and slices, it is likely that you will have `rustc` ask
   you to fix your code now.
+- Fix `Tess::instances` and `Tess::instances_mut` in the case of `Interleaved` memory. They didn’t return the right type
+  of slices and would  prevent people from even using them.
 
 # `luminance-derive`
 

--- a/examples/common/src/vertex_instancing.rs
+++ b/examples/common/src/vertex_instancing.rs
@@ -42,23 +42,23 @@ const TRI_VERTICES: [Vertex; 3] = [
 const INSTANCES: [Instance; 5] = [
   Instance {
     pos: VertexInstancePosition::new([0., 0.]),
-    w: VertexWeight::new(0.1),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([-0.5, 0.5]),
-    w: VertexWeight::new(0.5),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([-0.25, -0.1]),
-    w: VertexWeight::new(0.1),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([0.45, 0.25]),
-    w: VertexWeight::new(0.75),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([0.6, -0.3]),
-    w: VertexWeight::new(0.3),
+    w: VertexWeight::new(1.),
   },
 ];
 
@@ -102,6 +102,16 @@ impl Example for LocalExample {
         InputAction::Quit => return LoopFeedback::Exit,
 
         _ => (),
+      }
+    }
+
+    // make instances go boop boop by changing their weight dynamically
+    {
+      let mut instances = self.triangle.instances_mut().expect("instances");
+
+      for (i, instance) in instances.iter_mut().enumerate() {
+        let tcos = (t * (i + 1) as f32 * 0.5).cos().powf(2.);
+        instance.w = VertexWeight::new(tcos);
       }
     }
 

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -1009,9 +1009,9 @@ where
   /// This method gives access to the underlying _instance storage_.
   pub fn instances<'a>(
     &'a mut self,
-  ) -> Result<Instances<'a, B, V, I, W, Interleaved, V>, TessMapError>
+  ) -> Result<Instances<'a, B, V, I, W, Interleaved, W>, TessMapError>
   where
-    B: InstanceSliceBackend<'a, V, I, W, Interleaved, V>,
+    B: InstanceSliceBackend<'a, V, I, W, Interleaved, W>,
   {
     unsafe { B::instances(&mut self.repr).map(|repr| Instances { repr }) }
   }
@@ -1021,9 +1021,9 @@ where
   /// This method gives access to the underlying _instance storage_.
   pub fn instances_mut<'a>(
     &'a mut self,
-  ) -> Result<InstancesMut<'a, B, V, I, W, Interleaved, V>, TessMapError>
+  ) -> Result<InstancesMut<'a, B, V, I, W, Interleaved, W>, TessMapError>
   where
-    B: InstanceSliceBackend<'a, V, I, W, Interleaved, V>,
+    B: InstanceSliceBackend<'a, V, I, W, Interleaved, W>,
   {
     unsafe { B::instances_mut(&mut self.repr).map(|repr| InstancesMut { repr }) }
   }


### PR DESCRIPTION
The returned slice types were wrong and were using the `V` type
variable (the vertex type) instead of the `W` type (the instance type).