### PR TITLE
[luminance] Fix Tess::instances{,_mut}.

### DIFF
--- a/examples/common/src/vertex_instancing.rs
+++ b/examples/common/src/vertex_instancing.rs
@@ -42,23 +42,23 @@ const TRI_VERTICES: [Vertex; 3] = [
 const INSTANCES: [Instance; 5] = [
   Instance {
     pos: VertexInstancePosition::new([0., 0.]),
-    w: VertexWeight::new(0.1),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([-0.5, 0.5]),
-    w: VertexWeight::new(0.5),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([-0.25, -0.1]),
-    w: VertexWeight::new(0.1),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([0.45, 0.25]),
-    w: VertexWeight::new(0.75),
+    w: VertexWeight::new(1.),
   },
   Instance {
     pos: VertexInstancePosition::new([0.6, -0.3]),
-    w: VertexWeight::new(0.3),
+    w: VertexWeight::new(1.),
   },
 ];
 
@@ -102,6 +102,16 @@ impl Example for LocalExample {
         InputAction::Quit => return LoopFeedback::Exit,
 
         _ => (),
+      }
+    }
+
+    // make instances go boop boop by changing their weight dynamically
+    {
+      let mut instances = self.triangle.instances_mut().expect("instances");
+
+      for (i, instance) in instances.iter_mut().enumerate() {
+        let tcos = (t * (i + 1) as f32 * 0.5).cos().powf(2.);
+        instance.w = VertexWeight::new(tcos);
       }
     }
 

--- a/luminance/CHANGELOG.md
+++ b/luminance/CHANGELOG.md
@@ -9,8 +9,7 @@ how `cargo` resolves dependencies. `cargo update` is not enough, because all lum
 [SemVer ranges](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) to stay
 compatible with as many crates as possible. In that case, you want `cargo update --aggressive`.
 
-<!-- vim-markdown-toc GFM -->
-
+* [0.44.1](#0441)
 * [0.44](#044)
 * [0.43.2](#0432)
 * [0.43.1](#0431)
@@ -126,7 +125,12 @@ compatible with as many crates as possible. In that case, you want `cargo update
 * [0.2](#02)
 * [0.1](#01)
 
-<!-- vim-markdown-toc -->
+# 0.44.1
+
+> Sep 27, 2021
+
+- Fix `Tess::instances` and `Tess::instances_mut` returned slices, which were using the wrong type variables and made it
+  impossible to even compile that code. Because that situation couldn’t compile, we release this as a patch bump.
 
 # 0.44
 

--- a/luminance/Cargo.toml
+++ b/luminance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminance"
-version = "0.44.0"
+version = "0.44.1"
 license = "BSD-3-Clause"
 authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 description = "Stateless and type-safe graphics framework"

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -1034,9 +1034,9 @@ where
   /// Slice the [`Tess`] in order to read its content via usual slices.
   ///
   /// This method gives access to the underlying _instance storage_.
-  pub fn instances(&mut self) -> Result<Instances<B, V, I, W, Interleaved, V>, TessMapError>
+  pub fn instances(&mut self) -> Result<Instances<B, V, I, W, Interleaved, W>, TessMapError>
   where
-    B: InstanceSliceBackend<V, I, W, Interleaved, V>,
+    B: InstanceSliceBackend<V, I, W, Interleaved, W>,
   {
     unsafe { B::instances(&mut self.repr).map(|repr| Instances { repr }) }
   }
@@ -1044,9 +1044,9 @@ where
   /// Slice the [`Tess`] in order to read its content via usual slices.
   ///
   /// This method gives access to the underlying _instance storage_.
-  pub fn instances_mut(&mut self) -> Result<InstancesMut<B, V, I, W, Interleaved, V>, TessMapError>
+  pub fn instances_mut(&mut self) -> Result<InstancesMut<B, V, I, W, Interleaved, W>, TessMapError>
   where
-    B: InstanceSliceBackend<V, I, W, Interleaved, V>,
+    B: InstanceSliceBackend<V, I, W, Interleaved, W>,
   {
     unsafe { B::instances_mut(&mut self.repr).map(|repr| InstancesMut { repr }) }
   }


### PR DESCRIPTION
The returned slice types were wrong and were using the `V` type variable (the vertex type) instead of the `W` type (the instance type).