### PR TITLE
[luminance-derive] uminance-derive missing_docs.

### DIFF
--- a/examples/common/src/hello_world.rs
+++ b/examples/common/src/hello_world.rs
@@ -7,6 +7,8 @@
 //!
 //! <https://docs.rs/luminance>
 
+#![deny(missing_docs)]
+
 use crate::{Example, InputAction, LoopFeedback, PlatformServices};
 use luminance::{tess::Deinterleaved, Semantics, Vertex};
 use luminance_front::{
@@ -24,21 +26,21 @@ use luminance_front::{
 const VS: &'static str = include_str!("simple-vs.glsl");
 const FS: &'static str = include_str!("simple-fs.glsl");
 
-// Vertex semantics. Those are needed to instruct the GPU how to select vertex’s attributes from
-// the memory we fill at render time, in shaders. You don’t have to worry about them; just keep in
-// mind they’re mandatory and act as “protocol” between GPU’s memory regions and shaders.
-//
-// We derive Semantics automatically and provide the mapping as field attributes.
+/// Vertex semantics. Those are needed to instruct the GPU how to select vertex’s attributes from
+/// the memory we fill at render time, in shaders. You don’t have to worry about them; just keep in
+/// mind they’re mandatory and act as “protocol” between GPU’s memory regions and shaders.
+///
+/// We derive Semantics automatically and provide the mapping as field attributes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Semantics)]
 pub enum Semantics {
-  // - Reference vertex positions with the "co" variable in vertex shaders.
-  // - The underlying representation is [f32; 2], which is a vec2 in GLSL.
-  // - The wrapper type you can use to handle such a semantics is VertexPosition.
+  /// - Reference vertex positions with the "co" variable in vertex shaders.
+  /// - The underlying representation is [f32; 2], which is a vec2 in GLSL.
+  /// - The wrapper type you can use to handle such a semantics is VertexPosition.
   #[sem(name = "co", repr = "[f32; 2]", wrapper = "VertexPosition")]
   Position,
-  // - Reference vertex colors with the "color" variable in vertex shaders.
-  // - The underlying representation is [u8; 3], which is a uvec3 in GLSL.
-  // - The wrapper type you can use to handle such a semantics is VertexColor.
+  /// - Reference vertex colors with the "color" variable in vertex shaders.
+  /// - The underlying representation is [u8; 3], which is a uvec3 in GLSL.
+  /// - The wrapper type you can use to handle such a semantics is VertexColor.
   #[sem(name = "color", repr = "[u8; 3]", wrapper = "VertexColor")]
   Color,
 }
@@ -139,6 +141,7 @@ impl TessMethod {
   }
 }
 
+/// Local example; this will be picked by the example runner.
 pub struct LocalExample {
   program: Program<Semantics, (), ()>,
   direct_triangles: Tess<Vertex>,

--- a/luminance-derive/src/semantics.rs
+++ b/luminance-derive/src/semantics.rs
@@ -113,9 +113,10 @@ pub(crate) fn generate_enum_semantics_impl(
 
         // field-based code generation
         let field_gen = quote! {
-          // vertex attrib type
+          /// Vertex attribute type (representing #repr_ty_name).
           #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
           pub struct #ty_name {
+            /// Internal representation.
             pub repr: #repr_ty_name
           }
 
@@ -143,6 +144,7 @@ pub(crate) fn generate_enum_semantics_impl(
 
           // convert from the repr type to the vertex attrib type
           impl #ty_name {
+            /// Create a new vertex attribute based on its inner representation.
             pub const fn new(repr: #repr_ty_name) -> Self {
              #ty_name {
                repr

--- a/luminance-derive/src/vertex.rs
+++ b/luminance-derive/src/vertex.rs
@@ -211,6 +211,7 @@ fn process_struct(
 
     quote! {
       impl #struct_name {
+        /// Create a new vertex.
         pub const fn new(#(#i : #fields_types),*) -> Self {
           #struct_name ( #(#i),* )
         }
@@ -219,6 +220,7 @@ fn process_struct(
   } else {
     quote! {
       impl #struct_name {
+        /// Create a new vertex.
         pub const fn new(#(#fields_names : #fields_types),*) -> Self {
           #struct_name { #(#fields_names),* }
         }


### PR DESCRIPTION
The fix provides a default, simple documentation for the generated
symbols so that code depending on it and compiled with
`#![deny(missing_docs)]` or even `#![forbid(missing_docs)]` will still
pass.

Fixes #446.