### PR TITLE
[luminance-glfw] Bump version to 0.17.0

### DIFF
--- a/luminance-glfw/Cargo.toml
+++ b/luminance-glfw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminance-glfw"
-version = "0.16.0"
+version = "0.17.0"
 license = "BSD-3-Clause"
 authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 description = "GLFW support for luminance"


### PR DESCRIPTION
`luminance-windowing` has been [made deprecated](https://github.com/phaazon/luminance-rs/issues/555), and we should now use `luminance-glfw`'s [new api](https://github.com/phaazon/luminance-rs/blob/40b6802727fef1dcc7dd6a7c0f8cf3b7e37d7783/luminance-glfw/src/lib.rs#L84-L89).

However, in that process, `luminance-glfw` was not given a new version, which means that the only version available through cargo is at the time of writing [a version preceding `luminance-windowing`'s depreciation](https://github.com/phaazon/luminance-rs/commit/405e9c92cb26efa3bbc61276d0aaa595376d2d2b).
I should also note that `luminance-windowing`'s changes were major (the whole library was made deprecated), yet the release was made as a patch.

This commit simply bumps `luminance-glfw` to complete the work on deprecating `luminance-windowing`.