### PR TITLE
Fix clearing depth buffer when the previous pipeline set writes to off

### DIFF
--- a/luminance-gl/src/gl33/pipeline.rs
+++ b/luminance-gl/src/gl33/pipeline.rs
@@ -123,6 +123,7 @@ where
 
     if let Some(clear_depth) = pipeline_state.clear_depth {
       state.set_clear_depth(clear_depth);
+      state.set_depth_write(luminance::depth_stencil::Write::On);
       clear_buffer_bits |= gl::DEPTH_BUFFER_BIT;
     }
 

--- a/luminance-webgl/src/webgl2/pipeline.rs
+++ b/luminance-webgl/src/webgl2/pipeline.rs
@@ -124,6 +124,7 @@ where
 
     if let Some(clear_depth) = pipeline_state.clear_depth {
       state.set_clear_depth(clear_depth);
+      state.set_depth_write(luminance::depth_stencil::Write::On);
       clear_buffer_bits |= WebGl2RenderingContext::DEPTH_BUFFER_BIT;
     }
 


### PR DESCRIPTION
`gl{Color,Depth,Stencil}Mask` applies to `glClear`, so make sure the depth mask if off when clearing the depth buffer.

Luminance does not currently use any other mask than `glDepthMask`, so this should be sufficient.