### PR TITLE
Fix doc links to follow renaming `DepthSlot` to `DepthStencilSlot`.

### DIFF
--- a/luminance/src/backend/depth_stencil_slot.rs
+++ b/luminance/src/backend/depth_stencil_slot.rs
@@ -27,12 +27,14 @@ use crate::{
 ///
 /// - None, represented by the `()` implementor. This means that no depth and no stencil information will be available
 ///   for the framebuffer.
-/// - A single depth [`Texture`]. This type of depth/stenccil slot is often suitable for renderable framebuffer. The
+/// - A single depth [`Texture`]. This type of depth/stencil slot is often suitable for renderable framebuffer. The
 ///   pixel format must implement [`DepthPixel`].
 /// - A combined depth/stencil [`Texture`], allowing to use a depth buffer along with a stencil buffer.
 ///
 /// Feel free to have a look at the list of implementors of this trait to know which types you can use as depth and
 /// stencil slots.
+///
+/// [`DepthPixel`]: crate::pixel::DepthPixel
 pub trait DepthStencilSlot<B, D>
 where
   B: ?Sized + Framebuffer<D>,

--- a/luminance/src/backend/framebuffer.rs
+++ b/luminance/src/backend/framebuffer.rs
@@ -13,10 +13,12 @@ use crate::{
 /// A type implementing [`Framebuffer`] must implement [`TextureBase`] in the first place, because framebuffers and
 /// textures have a strong relationship.
 ///
-/// Framebuffers implement a strong type contract with the safe interface and are associated with [`ColorSlot`] and
-/// [`DepthSlot`]. Those types provide associated types to adapt the kind of data that will be allocated and provided to
-/// the user. For instance, if you want to have a framebuffer that will not have any depth information, you can use `()`
-/// as a [`DepthSlot`]. The backends will then not allocate anything and no depth data will be present at runtime.
+/// Framebuffers implement a strong type contract with the safe interface and are associated with
+/// [`ColorSlot`] and [`DepthStencilSlot`]. Those types provide associated types to adapt the kind
+/// of data that will be allocated and provided to the user. For instance, if you want to have a
+/// framebuffer that will not have any depth information, you can use `()` as a
+/// [`DepthStencilSlot`]. The backends will then not allocate anything and no depth data will be
+/// present at runtime.
 ///
 /// The whole process of implementing this trait revolves around three main aspects:
 ///
@@ -36,7 +38,7 @@ where
 
   /// Create a new framebuffer on the backend.
   ///
-  /// `CS` is the [`ColorSlot`] and `DS` is the [`DepthSlot`]. This function must create the part that is _only_
+  /// `CS` is the [`ColorSlot`] and `DS` is the [`DepthStencilSlot`]. This function must create the part that is _only_
   /// relevant to the framebuffer, not to the color slots directly. It can still allocate enough storage for the slots
   /// but it doesn’t have the handles / representations of the slots yet.
   unsafe fn new_framebuffer<CS, DS>(

--- a/luminance/src/texture.rs
+++ b/luminance/src/texture.rs
@@ -651,9 +651,9 @@ impl error::Error for TextureError {}
 /// - [`Texture::upload_part_raw`]
 /// - [`Texture::upload_raw`]
 ///
-/// In the second case, a [`Texture`] can be used as part of a [`ColorSlot`] or [`DepthSlot`] of a [`Framebuffer`]. This
-/// allows to create graphics pipeline that will output into the [`Texture`], that you can use in another graphics
-/// pipeline later.
+/// In the second case, a [`Texture`] can be used as part of a [`ColorSlot`] or [`DepthStencilSlot`]
+/// of a [`Framebuffer`]. This allows to create graphics pipeline that will output into the
+/// [`Texture`], that you can use in another graphics pipeline later.
 ///
 /// # Parametricity
 ///
@@ -679,7 +679,7 @@ impl error::Error for TextureError {}
 ///
 /// [`Framebuffer`]: crate::framebuffer::Framebuffer
 /// [`ColorSlot`]: crate::backend::color_slot::ColorSlot
-/// [`DepthSlot`]: crate::backend::depth_slot::DepthSlot
+/// [`DepthStencilSlot`]: crate::backend::depth_stencil_slot::DepthStencilSlot
 /// [`RenderablePixel`]: crate::pixel::RenderablePixel
 /// [`DepthPixel`]: crate::pixel::DepthPixel
 /// [`TextureBackend`]: crate::backend::texture::Texture


### PR DESCRIPTION
Also renamed one `depth_slot` variable for consistency, and made some minor rewordings.

This made comment lines longer — I rewrapped them to 100 characters (since rustfmt.toml specified that max length) even though the existing text in some files seemed wrapped to 120. Let me know if I should do something different.