### PR TITLE
[examples] Update `image` dependency to ^0.23.12.

### DIFF
--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -24,6 +24,6 @@ luminance = { version = "0.46", path = "../../luminance" }
 luminance-front = { version = "0.6", path = "../../luminance-front" }
 
 [dependencies.image]
-version = "0.23"
+version = "0.23.12"
 default-features = false
 features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]


### PR DESCRIPTION
`DynamicImage::to_rgb8()` was added in 0.23.12, and `ImageBuffer::as_raw()` was added in 0.23.10, so the existing version specification of 0.23 was too old.

I noticed this because when I updated my old clone of the luminance repository, the examples failed to compile due to the existing lock file specifying an older `image` version.