### PR TITLE
Remove Vertex::ATTR_COUNT.

### DIFF
--- a/luminance-derive/src/vertex.rs
+++ b/luminance-derive/src/vertex.rs
@@ -237,13 +237,9 @@ fn process_struct(
     )*
   };
 
-  let attr_count = fields_types.len();
-
   quote! {
     // Vertex impl
     unsafe impl luminance::vertex::Vertex for #struct_name {
-      const ATTR_COUNT: usize = #attr_count;
-
       fn vertex_desc() -> luminance::vertex::VertexDesc {
         vec![#(#indexed_vertex_attrib_descs),*]
       }

--- a/luminance/src/tess.rs
+++ b/luminance/src/tess.rs
@@ -756,7 +756,8 @@ where
       }
 
       None => {
-        let mut deinterleaved = vec![DeinterleavedData::new(); V::ATTR_COUNT];
+        let attrs = V::vertex_desc();
+        let mut deinterleaved = vec![DeinterleavedData::new(); attrs.len()];
         build_raw(&mut deinterleaved);
 
         self.vertex_data = Some(deinterleaved);
@@ -788,7 +789,8 @@ where
 
     match self.instance_data {
       None => {
-        let mut deinterleaved = vec![DeinterleavedData::new(); W::ATTR_COUNT];
+        let attrs = W::vertex_desc();
+        let mut deinterleaved = vec![DeinterleavedData::new(); attrs.len()];
         build_raw(&mut deinterleaved);
 
         self.instance_data = Some(deinterleaved);

--- a/luminance/src/vertex.rs
+++ b/luminance/src/vertex.rs
@@ -20,16 +20,11 @@ use std::fmt::Debug;
 ///
 /// > Note: implementing this trait is `unsafe`.
 pub unsafe trait Vertex: Copy {
-  /// Number of attributes.
-  const ATTR_COUNT: usize;
-
   /// The associated vertex format.
   fn vertex_desc() -> VertexDesc;
 }
 
 unsafe impl Vertex for () {
-  const ATTR_COUNT: usize = 0;
-
   fn vertex_desc() -> VertexDesc {
     Vec::new()
   }


### PR DESCRIPTION
This was redundant as vec![_; HERE] doesn’t require `const` items (anymore?).