### PR TITLE
Fix source link for luminance doc logo

### DIFF
--- a/luminance/src/lib.rs
+++ b/luminance/src/lib.rs
@@ -318,7 +318,7 @@
 //! [`UniformInterface`]: https://docs.rs/luminance/latest/luminance/shader/program/trait.UniformInterface.html
 
 #![doc(
-  html_logo_url = "https://github.com/phaazon/luminance-rs/blob/master/docs/imgs/luminance_alt.svg"
+  html_logo_url = "https://raw.githubusercontent.com/phaazon/luminance-rs/master/docs/imgs/luminance_alt.svg"
 )]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
It's currently broken:

<img width="544" alt="Screenshot 2022-04-10 at 15 03 29" src="https://user-images.githubusercontent.com/3050060/162619571-b5576e55-224b-4447-b8cb-b5a8d9310fdf.png">

