### PR TITLE
Use a type family and GAT to simplify vertex entity memory schemes.

### DIFF
--- a/examples/common/src/dynamic_uniform_interface.rs
+++ b/examples/common/src/dynamic_uniform_interface.rs
@@ -24,7 +24,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 
 const VS: &'static str = include_str!("displacement-vs.glsl");
@@ -62,7 +62,7 @@ const TRI_VERTICES: [Vertex; 3] = [
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>, // no uniform environment; we want dynamic lookups
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   triangle_pos: mint::Vector2<f32>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,
 }

--- a/examples/common/src/hello_world.rs
+++ b/examples/common/src/hello_world.rs
@@ -15,7 +15,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   RenderSlots, Vertex,
 };
 
@@ -121,7 +121,7 @@ pub struct LocalExample {
   back_buffer: Framebuffer<Dim2, Back<Slots>, Back<()>>,
   // the program will render by mapping our Vertex type as triangles to the color slot, containing a single color
   program: Program<Vertex, (), Triangle, Slots, ()>,
-  triangles: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangles: VertexEntity<Vertex, Triangle, Interleaving>,
 }
 
 impl Example for LocalExample {

--- a/examples/common/src/hello_world_more.rs
+++ b/examples/common/src/hello_world_more.rs
@@ -20,7 +20,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::{Deinterleaved, Interleaved},
+  vertex_storage::{Deinterleaved, Deinterleaving, Interleaved, Interleaving},
   RenderSlots, Vertex,
 };
 
@@ -184,10 +184,10 @@ pub struct LocalExample {
   back_buffer: Framebuffer<Dim2, Back<Slots>, Back<()>>,
   // the program will render by mapping our Vertex type as triangles to the color slot, containing a single color
   program: Program<Vertex, (), Triangle, Slots, ()>,
-  direct_triangles: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
-  indexed_triangles: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
-  direct_deinterleaved_triangles: VertexEntity<Vertex, Triangle, Deinterleaved<Vertex>>,
-  indexed_deinterleaved_triangles: VertexEntity<Vertex, Triangle, Deinterleaved<Vertex>>,
+  direct_triangles: VertexEntity<Vertex, Triangle, Interleaving>,
+  indexed_triangles: VertexEntity<Vertex, Triangle, Interleaving>,
+  direct_deinterleaved_triangles: VertexEntity<Vertex, Triangle, Deinterleaving>,
+  indexed_deinterleaved_triangles: VertexEntity<Vertex, Triangle, Deinterleaving>,
   method: Method,
 }
 

--- a/examples/common/src/interactive_triangle.rs
+++ b/examples/common/src/interactive_triangle.rs
@@ -22,7 +22,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 use mint::{Vector2, Vector3};
 
@@ -87,7 +87,7 @@ fn window_to_screen(a: &Vector2<f32>, w: f32, h: f32) -> Vector2<f32> {
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   // current cursor position
   cursor_pos: Option<Vector2<f32>>,
   // when we press down a button, if we are to select a vertex, we need to know which one; this

--- a/examples/common/src/mrt.rs
+++ b/examples/common/src/mrt.rs
@@ -20,7 +20,7 @@ use luminance::{
   shader::{Program, ProgramBuilder, Uni},
   texture::{InUseTexture, Mipmaps, TextureSampling},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   RenderSlots, Uniforms,
 };
 use mint::{Vector2, Vector3};
@@ -82,7 +82,7 @@ struct OffscreenSlots {
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, OffscreenSlots, ()>,
   copy_program: Program<(), (), TriangleFan, FragSlot, ShaderInterface>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   quad: VertexEntity<(), TriangleFan, ()>,
   offscreen_buffer: Framebuffer<Dim2, OffscreenSlots, ()>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,

--- a/examples/common/src/offscreen.rs
+++ b/examples/common/src/offscreen.rs
@@ -15,7 +15,7 @@ use luminance::{
   shader::{Program, ProgramBuilder, Uni},
   texture::{InUseTexture, Mipmaps, TextureSampling},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   Uniforms,
 };
 
@@ -73,7 +73,7 @@ struct Uniforms {
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>,
   copy_program: Program<(), (), TriangleFan, FragSlot, Uniforms>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   quad: VertexEntity<(), TriangleFan, ()>,
   offscreen_buffer: Framebuffer<Dim2, FragSlot, ()>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,

--- a/examples/common/src/query_texture_texels.rs
+++ b/examples/common/src/query_texture_texels.rs
@@ -21,7 +21,7 @@ use luminance::{
   shader::{Program, ProgramBuilder},
   texture::{Mipmaps, TextureSampling},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 use mint::{Vector2, Vector3};
 
@@ -85,7 +85,7 @@ const TRI_VERTICES: [Vertex; 6] = [
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>,
-  triangles: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangles: VertexEntity<Vertex, Triangle, Interleaving>,
   framebuffer: Framebuffer<Dim2, FragSlot, ()>,
 }
 

--- a/examples/common/src/render_state.rs
+++ b/examples/common/src/render_state.rs
@@ -20,7 +20,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 use mint::{Vector2, Vector3};
 
@@ -116,8 +116,8 @@ fn toggle_blending(blending: BlendingMode) -> BlendingMode {
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>,
-  red_triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
-  blue_triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  red_triangle: VertexEntity<Vertex, Triangle, Interleaving>,
+  blue_triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   blending: BlendingMode,
   depth_method: DepthMethod,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,

--- a/examples/common/src/shader_uniforms.rs
+++ b/examples/common/src/shader_uniforms.rs
@@ -21,7 +21,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder, Uni},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   Uniforms,
 };
 use mint::{Vector2, Vector3};
@@ -75,7 +75,7 @@ struct ShaderUniforms {
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ShaderUniforms>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   triangle_pos: Vector2<f32>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,
 }

--- a/examples/common/src/skybox.rs
+++ b/examples/common/src/skybox.rs
@@ -31,7 +31,7 @@ use luminance::{
   shader::{Program, ProgramBuilder, Uni},
   texture::{InUseTexture, Mipmaps, Texture, TextureSampling},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   Uniforms,
 };
 use mint::ColumnMatrix4;
@@ -133,7 +133,7 @@ pub struct LocalExample {
   env_map_program:
     Program<CubeVertex, (), TriangleStrip, FragSlot, EnvironmentMappingShaderInterface>,
   fullscreen_quad: VertexEntity<(), TriangleStrip, ()>,
-  cube: VertexEntity<CubeVertex, TriangleStrip, Interleaved<CubeVertex>>,
+  cube: VertexEntity<CubeVertex, TriangleStrip, Interleaving>,
   last_cursor_pos: Option<cgmath::Vector2<f32>>,
   rotate_viewport: bool,
   x_theta: f32,

--- a/examples/common/src/sliced_vertex_entity.rs
+++ b/examples/common/src/sliced_vertex_entity.rs
@@ -23,7 +23,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View as _},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 use mint::{Vector2, Vector3};
 
@@ -108,7 +108,7 @@ impl ViewMethod {
 
 pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, ()>,
-  triangles: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangles: VertexEntity<Vertex, Triangle, Interleaving>,
   view_method: ViewMethod,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,
 }

--- a/examples/common/src/stencil.rs
+++ b/examples/common/src/stencil.rs
@@ -17,7 +17,7 @@ use luminance::{
   shader::{Program, ProgramBuilder, Uni},
   texture::{InUseTexture, Mipmaps, TextureSampling},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   Uniforms,
 };
 
@@ -86,7 +86,7 @@ pub struct LocalExample {
   program: Program<Vertex, (), Triangle, FragSlot, StencilInterface>,
   copy_program: Program<(), (), TriangleFan, FragSlot, ShaderCopyInterface>,
   framebuffer: Framebuffer<Dim2, FragSlot, Depth32FStencil8>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving>,
   attributeless: VertexEntity<(), TriangleFan, ()>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,
 }

--- a/examples/common/src/uni_buffer.rs
+++ b/examples/common/src/uni_buffer.rs
@@ -18,7 +18,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder, Std140, Uni, UniBuffer},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
   Std140, Uniforms,
 };
 
@@ -77,7 +77,7 @@ pub struct UniBlock {
 }
 
 pub struct LocalExample {
-  square: VertexEntity<Vertex, TriangleFan, Interleaved<Vertex>>,
+  square: VertexEntity<Vertex, TriangleFan, Interleaving>,
   program: Program<Vertex, (), TriangleFan, FragSlot, ShaderUniforms>,
   uni_buffer: UniBuffer<UniBlock, Std140>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,

--- a/examples/common/src/vertex_instancing.rs
+++ b/examples/common/src/vertex_instancing.rs
@@ -16,7 +16,7 @@ use luminance::{
   render_state::RenderState,
   shader::{Program, ProgramBuilder},
   vertex_entity::{VertexEntity, VertexEntityBuilder, View},
-  vertex_storage::Interleaved,
+  vertex_storage::{Interleaved, Interleaving},
 };
 
 const VS: &'static str = include_str!("instancing-vs.glsl");
@@ -78,7 +78,7 @@ const INSTANCES: [Instance; 5] = [
 
 pub struct LocalExample {
   program: Program<Vertex, Instance, Triangle, FragSlot, ()>,
-  triangle: VertexEntity<Vertex, Triangle, Interleaved<Vertex>, Instance, Interleaved<Instance>>,
+  triangle: VertexEntity<Vertex, Triangle, Interleaving, Instance, Interleaving>,
   back_buffer: Framebuffer<Dim2, Back<FragSlot>, Back<()>>,
 }
 

--- a/luminance-gl2/src/gl33.rs
+++ b/luminance-gl2/src/gl33.rs
@@ -25,7 +25,9 @@ use luminance::{
     Normalized, Vertex, VertexAttribDesc, VertexAttribDim, VertexAttribType, VertexBufferDesc,
   },
   vertex_entity::{VertexEntity, VertexEntityBuilder, VertexEntityView},
-  vertex_storage::{AsVertexStorage, Deinterleaved, Interleaved, VertexStorage},
+  vertex_storage::{
+    AsVertexStorage, Deinterleaved, Interleaved, VertexStorage, VertexStorageFamily,
+  },
 };
 use std::{
   cell::RefCell,
@@ -2070,16 +2072,16 @@ unsafe impl Backend for GL33 {
 }
 
 unsafe impl VertexEntityBackend for GL33 {
-  unsafe fn new_vertex_entity<V, P, VS, W, WS>(
+  unsafe fn new_vertex_entity<V, P, VSF, W, WSF>(
     &mut self,
-    mut builder: VertexEntityBuilder<VS, WS>,
-  ) -> Result<VertexEntity<V, P, VS, W, WS>, VertexEntityError>
+    mut builder: VertexEntityBuilder<VSF::Storage<V>, WSF::Storage<W>>,
+  ) -> Result<VertexEntity<V, P, VSF, W, WSF>, VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
     W: Vertex,
-    WS: AsVertexStorage<W>,
+    WSF: VertexStorageFamily,
   {
     let indices = builder.indices;
 

--- a/luminance/src/backend.rs
+++ b/luminance/src/backend.rs
@@ -12,7 +12,7 @@ use crate::{
   texture::{InUseTexture, Mipmaps, Texture, TextureSampling},
   vertex::Vertex,
   vertex_entity::{VertexEntity, VertexEntityBuilder, VertexEntityView},
-  vertex_storage::AsVertexStorage,
+  vertex_storage::{AsVertexStorage, VertexStorageFamily},
 };
 use std::{collections::HashMap, error::Error as ErrorTrait, fmt};
 
@@ -682,16 +682,16 @@ pub unsafe trait Backend:
 }
 
 pub unsafe trait VertexEntityBackend {
-  unsafe fn new_vertex_entity<V, P, VS, W, WS>(
+  unsafe fn new_vertex_entity<V, P, VSF, W, WSF>(
     &mut self,
-    builder: VertexEntityBuilder<VS, WS>,
-  ) -> Result<VertexEntity<V, P, VS, W, WS>, VertexEntityError>
+    builder: VertexEntityBuilder<VSF::Storage<V>, WSF::Storage<W>>,
+  ) -> Result<VertexEntity<V, P, VSF, W, WSF>, VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
     W: Vertex,
-    WS: AsVertexStorage<W>;
+    WSF: VertexStorageFamily;
 
   unsafe fn vertex_entity_render<V, P>(
     &self,

--- a/luminance/src/context.rs
+++ b/luminance/src/context.rs
@@ -18,7 +18,7 @@ use crate::{
   texture::{InUseTexture, Mipmaps, Texture, TextureSampling},
   vertex::Vertex,
   vertex_entity::{VertexEntity, VertexEntityBuilder},
-  vertex_storage::AsVertexStorage,
+  vertex_storage::VertexStorageFamily,
 };
 
 #[derive(Clone, Debug)]
@@ -73,28 +73,30 @@ where
     self.backend.backend_shading_lang_version()
   }
 
-  pub fn new_vertex_entity<V, P, VS, W, WS>(
+  pub fn new_vertex_entity<V, P, VSF, W, WSF>(
     &mut self,
-    builder: VertexEntityBuilder<VS, WS>,
-  ) -> Result<VertexEntity<V, P, VS, W, WS>, VertexEntityError>
+    builder: VertexEntityBuilder<VSF::Storage<V>, WSF::Storage<W>>,
+  ) -> Result<VertexEntity<V, P, VSF, W, WSF>, VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
     W: Vertex,
-    WS: AsVertexStorage<W>,
+    WSF: VertexStorageFamily,
   {
     unsafe { self.backend.new_vertex_entity(builder) }
   }
 
-  pub fn update_vertices<V, P, VS>(
+  pub fn update_vertices<V, P, VSF, W, WSF>(
     &mut self,
-    entity: &mut VertexEntity<V, P, VS>,
+    entity: &mut VertexEntity<V, P, VSF, W, WSF>,
   ) -> Result<(), VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
+    W: Vertex,
+    WSF: VertexStorageFamily,
   {
     unsafe {
       self
@@ -103,16 +105,16 @@ where
     }
   }
 
-  pub fn update_indices<V, P, VS, W, WS>(
+  pub fn update_indices<V, P, VSF, W, WSF>(
     &mut self,
-    entity: &mut VertexEntity<V, P, VS, W, WS>,
+    entity: &mut VertexEntity<V, P, VSF, W, WSF>,
   ) -> Result<(), VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
     W: Vertex,
-    WS: AsVertexStorage<W>,
+    WSF: VertexStorageFamily,
   {
     unsafe {
       self
@@ -121,16 +123,16 @@ where
     }
   }
 
-  pub fn update_instance_data<V, P, VS, W, WS>(
+  pub fn update_instance_data<V, P, VSF, W, WSF>(
     &mut self,
-    entity: &mut VertexEntity<V, P, VS, W, WS>,
+    entity: &mut VertexEntity<V, P, VSF, W, WSF>,
   ) -> Result<(), VertexEntityError>
   where
     V: Vertex,
     P: Primitive,
-    VS: AsVertexStorage<V>,
+    VSF: VertexStorageFamily,
     W: Vertex,
-    WS: AsVertexStorage<W>,
+    WSF: VertexStorageFamily,
   {
     unsafe {
       self

--- a/luminance/src/vertex_storage.rs
+++ b/luminance/src/vertex_storage.rs
@@ -35,6 +35,28 @@ impl<V> AsVertexStorage<V> for Deinterleaved<V> {
   }
 }
 
+pub trait VertexStorageFamily {
+  type Storage<V>: AsVertexStorage<V>;
+}
+
+impl VertexStorageFamily for () {
+  type Storage<V> = ();
+}
+
+#[derive(Debug)]
+pub struct Interleaving;
+
+impl VertexStorageFamily for Interleaving {
+  type Storage<V> = Interleaved<V>;
+}
+
+#[derive(Debug)]
+pub struct Deinterleaving;
+
+impl VertexStorageFamily for Deinterleaving {
+  type Storage<V> = Deinterleaved<V>;
+}
+
 /// Store vertices as an interleaved array.
 #[derive(Debug)]
 pub struct Interleaved<V> {


### PR DESCRIPTION
Instead of using VertexEntity<V, …, Interleaved<V>, …>, one can now use something like VertexEntity<V, …, Interleaving, …>. The way it works is by implementing a new trait, VertexStorageFamily, which has an associated type (type family) using a GAT:

  type Storage<V>: AsVertexStorage<V>;