### PR TITLE
Correct line numbers in GLSL errors

### DIFF
--- a/luminance-gl/src/gl33/shader.rs
+++ b/luminance-gl/src/gl33/shader.rs
@@ -255,13 +255,15 @@ fn opengl_shader_type(t: StageType) -> GLenum {
 
 #[cfg(feature = "GL_ARB_gpu_shader_fp64")]
 const GLSL_PRAGMA: &str = "#version 330 core\n\
-                           #extension GL_ARB_separate_shader_objects : require\n
+                           #extension GL_ARB_separate_shader_objects : require\n\
                            #extension GL_ARB_gpu_shader_fp64 : require\n\
-                           layout(std140) uniform;\n";
+                           layout(std140) uniform;\n\
+                           #line 1\n";
 #[cfg(not(feature = "GL_ARB_gpu_shader_fp64"))]
 const GLSL_PRAGMA: &str = "#version 330 core\n\
                            #extension GL_ARB_separate_shader_objects : require\n\
-                           layout(std140) uniform;\n";
+                           layout(std140) uniform;\n\
+                           #line 1\n";
 
 fn glsl_pragma_src(src: &str) -> String {
   let mut pragma = String::from(GLSL_PRAGMA);

--- a/luminance-webgl/src/webgl2/shader.rs
+++ b/luminance-webgl/src/webgl2/shader.rs
@@ -315,8 +315,9 @@ fn webgl_shader_type(ty: StageType) -> Option<u32> {
 
 const GLSL_PRAGMA: &str = "#version 300 es\n\
                            precision highp float;\n\
-                           precision highp int;
-                           layout(std140) uniform;\n";
+                           precision highp int;\n\
+                           layout(std140) uniform;\n\
+                           #line 1\n";
 
 fn patch_shader_src(src: &str) -> String {
   let mut pragma = String::from(GLSL_PRAGMA);


### PR DESCRIPTION
Adds a #line directive to the GLSL headers that luminance-gl and luminance-webgl prepend to GLSL source, so that if an error occurs, the reported line number will match the user's provided GLSL source rather than being offset a few lines.